### PR TITLE
Use setuptools_scm for versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ core.*
 /*.tim
 *.pickle.gz
 /*.out
+
+# dynamic version file
+_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools_scm[toml]"]
+requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools_scm[toml]"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pint_pal"
-version = "0.1.0"
+dynamic = ["version"]
 authors = [
   { name="Joe Glaser", email="joe.glaser@nanograv.org" },
   { name="Joe Swiggum", email="joe.swiggum@nanograv.org" },
@@ -25,3 +25,6 @@ classifiers = [
 [project.urls]
 "Homepage" = "https://github.com/nanograv/pint_pal"
 "Bug Tracker" = "https://github.com/nanograv/pint_pal/issues"
+
+[tool.setuptools_scm]
+write_to = "src/pint_pal/_version.py"

--- a/src/pint_pal/__init__.py
+++ b/src/pint_pal/__init__.py
@@ -1,1 +1,2 @@
 import pint_pal.checkin
+from pint_pal._version import __version__, version

--- a/src/pint_pal/__init__.py
+++ b/src/pint_pal/__init__.py
@@ -1,2 +1,7 @@
 import pint_pal.checkin
-from pint_pal._version import __version__, version
+try:
+    from setuptools_scm import get_version
+    __version__ = get_version(root='..', relative_to=__file__)
+except (LookupError, ModuleNotFoundError):
+    # not an editable install, use build-time version
+    from pint_pal._version import __version__


### PR DESCRIPTION
This PR implements versioning using [`setuptools_scm`](https://github.com/pypa/setuptools_scm), resolving issue #25 (lack of good version numbering). This is similar to, but simpler than, PINT's use of [Versioneer](https://github.com/python-versioneer/python-versioneer). I had been looking into using `setuptools_scm` for a different project and remembered that we had never settled the versioning issue for PINT Pal, so I decided to make this PR.

With this in place, you can get the version number at run time as either `pint_pal.version` or `pint_pal.__version__`. This version number is based on the tags in git -- `setuptools_scm` searches back through the git history for the most recent tagged commit, and builds the version based on that. If the current commit is the tagged one, it just uses the tag as the version number, and otherwise it tries to guess the next version number and adds `.dev{distance}+g{hash}` to the end of it, based on the distance from the tagged commit and the current commit hash. For example, the current version reports as `0.1.1.dev16+g950bd5b`.