### PR TITLE
Fix path handling in notebook runner to allow use with IPTA DR3

### DIFF
--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -19,7 +19,9 @@ jobs:
 
     steps:
     - name: Install pdflatex
-      run: sudo apt-get install texlive-latex-base pdftk latex2html
+      run: |
+        sudo apt-get update
+        sudo apt-get install texlive-latex-base pdftk latex2html
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3

--- a/src/pint_pal/notebook_runner.py
+++ b/src/pint_pal/notebook_runner.py
@@ -6,6 +6,8 @@ import re
 from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
 import multiprocessing
 from glob import glob
+from ruamel.yaml import YAML
+yaml = YAML(typ='safe')
 
 import pint_pal
 from pint_pal.notebook_templater import transform_notebook
@@ -36,10 +38,17 @@ def run_notebook(template_nb, config_file, output_nb=None, err_file=None, workdi
     if log_status_to is None:
         log_status_to = sys.stdout
 
+    with open(config_file) as f:
+        config = yaml.load(f)
+    par_directory = config['par-directory']
+    tim_directory = config['tim-directory']
+    par_directory = os.path.normpath(os.path.join(base_dir, par_directory))
+    tim_directory = os.path.normpath(os.path.join(base_dir, tim_directory))
+
     default_transformations = {
         'config': f'"{config_file}"',
-        'par_directory': f'"{os.path.join(base_dir, "results")}"',
-        'tim_directory': f'"{os.path.join(base_dir, "tim")}"',
+        'par_directory': f'"{par_directory}"',
+        'tim_directory': f'"{tim_directory}"',
     }
     if transformations is None:
         transformations = default_transformations

--- a/src/pint_pal/notebook_runner.py
+++ b/src/pint_pal/notebook_runner.py
@@ -38,6 +38,7 @@ def run_notebook(template_nb, config_file, output_nb=None, err_file=None, workdi
     if log_status_to is None:
         log_status_to = sys.stdout
 
+    config_file = os.path.abspath(config_file)
     with open(config_file) as f:
         config = yaml.load(f)
     par_directory = config['par-directory']

--- a/src/pint_pal/notebook_runner.py
+++ b/src/pint_pal/notebook_runner.py
@@ -14,7 +14,8 @@ from pint_pal.notebook_templater import transform_notebook
 
 ansi_color = re.compile(r'\x1b\[([0-9]{1,3};)*[0-9]{1,3}m')
 
-def run_notebook(template_nb, config_file, output_nb=None, err_file=None, workdir=None, log_status_to=None, color_err=False, verbose=False, transformations=None):
+def run_template_notebook(template_nb, config_file, output_nb=None, err_file=None, output_dir=None,
+                          log_status_to=None, color_err=False, verbose=False, transformations=None):
     """
     Run a template notebook with a set of transformations and save the completed notebook,
     log, and error traceback (if any).
@@ -23,9 +24,12 @@ def run_notebook(template_nb, config_file, output_nb=None, err_file=None, workdi
     ----------
     template_nb:     Template notebook to use.
     config_file:     Configuration file (YAML).
-    output_nb:       Location to write the completed notebook.
-    err_file:        Location to write the error traceback log (if necessary).
-    workdir:         Directory in which to work (default: current working directory).
+    output_nb:       Location to write the completed notebook
+                     (if `None`, use template notebook filename).
+    err_file:        Location to write the error traceback log
+                     (if `None`, create based on template notebook filename).
+    output_dir:      Location where output will be written (default: current working directory).
+                     A new subdirectory will be created with a name based on the config file name.
     log_status_to:   File-like object (stream) to write status (success/failure) to
                      (default: stdout).
     color_err:       Whether to keep ANSI color codes in the error traceback.
@@ -35,9 +39,20 @@ def run_notebook(template_nb, config_file, output_nb=None, err_file=None, workdi
     # base_dir = parent directory of directory containing config_file
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(config_file)))
 
-    # workdir = current working directory
-    if workdir is None:
-        workdir = os.getcwd()
+    nb_name = os.path.splitext(os.path.split(template_nb)[1])[0]
+    cfg_name = os.path.splitext(os.path.split(config_file)[1])[0]
+    if output_dir is None:
+        output_dir = os.getcwd()
+
+    # Create working directory within output_dir
+    workdir = os.path.join(output_dir, cfg_name)
+    os.makedirs(workdir)
+
+    # Fill in output filenames, if unspecified
+    if output_nb is None:
+        output_nb = os.path.join(workdir, f'{nb_name}.ipynb')
+    if err_file is None:
+        err_file = os.path.join(workdir, f'{nb_name}.traceback')
     if log_status_to is None:
         log_status_to = sys.stdout
 
@@ -78,11 +93,10 @@ def run_notebook(template_nb, config_file, output_nb=None, err_file=None, workdi
     try:
         ep.preprocess(nb, {'metadata': {'path': workdir}})
     except CellExecutionError as err:
-        if err_file is not None:
-            with open(err_file, 'w') as f:
-                if not color_err:
-                    traceback = re.sub(ansi_color, '', err.traceback)
-                print(traceback, file=f)
+        with open(err_file, 'w') as f:
+            if not color_err:
+                traceback = re.sub(ansi_color, '', err.traceback)
+            print(traceback, file=f)
         if hasattr(err, 'ename'):
             print(f"{cfg_name}: failure - {err.ename}", file=log_status_to)
         else:
@@ -93,54 +107,3 @@ def run_notebook(template_nb, config_file, output_nb=None, err_file=None, workdi
             with open(output_nb, 'w', encoding='utf-8') as f:
                 nbformat.write(nb, f)
     print(f"{cfg_name}: success!", file=log_status_to)
-
-def run_in_subdir(template_nb, config_file, output_dir=None, log_status_to=None, verbose=False, transformations=None):
-    """
-    Given a template notebook and configuration file, create a subdirectory with a name
-    based on the configuration file and run the notebook inside it. Some transformations
-    (write_prenoise, write_results, use_existing_noise_dir, log_to_file) are turned on
-    by default. This function is called directly by test_run_notebook.py.
-    
-    Parameters
-    ----------
-    template_nb:     Template notebook to use.
-    config_file:     Configuration file to use.
-    output_dir:      Location where the subdirectory will be created
-                     (default: current working directory).
-    log_status_to:   File-like object (stream) to write status (success/failure) to
-                     (default: stdout).
-    verbose:         Print a description of replacements made in the template notebook.
-    transformations: Transformations to apply to the notebook.
-    """
-    if output_dir is None:
-        output_dir = os.getcwd()
-    if log_status_to is None:
-        log_status_to = sys.stdout
-
-    output_transformations = {
-        'write_prenoise': "True",
-        'write_results': "True",
-        'use_existing_noise_dir': "True",
-        'log_to_file': "True",
-    }
-    if transformations is None:
-        transformations = output_transformations
-    else:
-        transformations = {**output_transformations, **transformations}
-
-    cfg_name = os.path.splitext(os.path.split(config_file)[1])[0]
-    cfg_dir = os.path.join(output_dir, cfg_name)
-    os.makedirs(cfg_dir)
-    err_file = os.path.join(cfg_dir, f'{cfg_name}.traceback')
-    output_nb = os.path.join(cfg_dir, f'{cfg_name}.ipynb')
-
-    run_notebook(
-        template_nb,
-        config_file,
-        output_nb,
-        err_file = err_file,
-        workdir = cfg_dir,
-        verbose = verbose,
-        log_status_to = log_status_to,
-        transformations = transformations,
-    )

--- a/src/pint_pal/notebook_runner.py
+++ b/src/pint_pal/notebook_runner.py
@@ -32,19 +32,31 @@ def run_notebook(template_nb, config_file, output_nb=None, err_file=None, workdi
     verbose:         Print a description of replacements made in the template notebook.
     transformations: Transformations to apply to the notebook.
     """
+    # base_dir = parent directory of directory containing config_file
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(config_file)))
+
+    # workdir = current working directory
     if workdir is None:
         workdir = os.getcwd()
     if log_status_to is None:
         log_status_to = sys.stdout
 
+    # Find absolute path to config_file (look in current working directory)
+    # os.path.abspath() and os.path.normpath() will leave absolute paths alone
     config_file = os.path.abspath(config_file)
+
+    # Find absolute paths to par_directory and tim_directory (look in base_dir)
     with open(config_file) as f:
         config = yaml.load(f)
     par_directory = config['par-directory']
     tim_directory = config['tim-directory']
     par_directory = os.path.normpath(os.path.join(base_dir, par_directory))
     tim_directory = os.path.normpath(os.path.join(base_dir, tim_directory))
+
+    # Find absolute path to template_nb (look in "pint_pal/nb_templates")
+    pint_pal_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    template_dir = os.path.join(pint_pal_dir, 'nb_templates')
+    template_nb = os.path.normpath(os.path.join(template_dir, template_nb))
 
     default_transformations = {
         'config': f'"{config_file}"',

--- a/tests/configs/J0605+3757.nb.yaml
+++ b/tests/configs/J0605+3757.nb.yaml
@@ -1,6 +1,6 @@
 source: J0605+3757
-par-directory: tests/results/
-tim-directory: tests/tim/
+par-directory: results/
+tim-directory: tim/
 timing-model: J0605+3757_PINT_20220301.nb.par
 compare-model: archive/J0605+3757_PINT_20220223.nb.par
 toas:

--- a/tests/configs/J0605+3757.wb.yaml
+++ b/tests/configs/J0605+3757.wb.yaml
@@ -1,6 +1,6 @@
 source: J0605+3757
-par-directory: tests/results/
-tim-directory: tests/tim/
+par-directory: results/
+tim-directory: tim/
 timing-model: J0605+3757_PINT_20221021.wb.par
 compare-model:
     #archive/J0605+3757_PINT_20220824.wb.par

--- a/tests/test_run_notebook.py
+++ b/tests/test_run_notebook.py
@@ -3,7 +3,7 @@ from os.path import dirname, join, split, splitext
 from datetime import datetime
 from glob import glob
 import pytest
-from pint_pal.notebook_runner import run_in_subdir
+from pint_pal.notebook_runner import run_template_notebook
 
 base_dir = dirname(dirname(__file__))
 
@@ -40,9 +40,15 @@ def test_run_notebook(config_file, output_dir):
     """
     global_log = join(output_dir, f'test-run-notebook.log')
     with open(global_log, 'a') as f:
-        run_in_subdir(
-            join(base_dir, 'nb_templates/process_v1.2.ipynb'),
+        run_template_notebook(
+            'process_v1.2.ipynb',
             config_file,
-            output_dir,
-            log_status_to = f,
+            output_dir=output_dir,
+            log_status_to=f,
+            transformations = {
+                'write_prenoise': "True",
+                'write_results': "True",
+                'use_existing_noise_dir': "True",
+                'log_to_file': "True",
+            },
         )


### PR DESCRIPTION
This makes the path handling in the notebook runner a bit more flexible, in a way that should make it possible to do notebook autoruns for IPTA DR3 and other future datasets where we use pint_pal as a standalone package. None of the changes should affect the way we had been doing notebook autoruns for the NANOGrav 15-year dataset.

Specifically, the changes are:
- `run_in_subdir()`, which contained substitutions specific to the 15-year process notebook as well as functionality to create a new subdirectory and run the notebook in it, has been eliminated. The 15-year-specific substitutions have been moved to `test_run_notebook()`, and the subdirectory functionality has been moved to `run_notebook()`, which I renamed `run_template_notebook()`.
- `run_template_notebook()` no longer overrides the `tim-directory` and `par-directory` specified in config files. Instead, if they are not absolute paths, it treats them as relative to the parent directory of the directory containing the config file, which is a convention we have continued to adhere to for IPTA DR3.
- `run_template_notebook()` can now accept relative paths for the `template_nb` and `config_file` arguments, in addition to absolute paths. For `template_nb`, the path is treated as relative to the `pint_pal/nb_templates` directory, while for `config_file`, it is treated as relative to the current working directory.