### PR TITLE
Added compatibility with pl_DM_noise red noise DM modeling

### DIFF
--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -42,8 +42,12 @@ def whiten_resids(fitter, restype = 'postfit'):
         rs = fitter['time_resids']
         noise_rs = fitter['noise_resids']
         # Now check if red noise residuals
-        if "pl_red_noise" in noise_rs:
+        if "pl_red_noise" and "pl_DM_noise" in noise_rs:
+            wres = rs - noise_rs['pl_red_noise'] - noise_rs['pl_DM_noise']
+        elif "pl_red_noise" in noise_rs:
             wres = rs - noise_rs['pl_red_noise']
+        elif "pl_DM_noise" in noise_rs:
+            wres = rs - noise_rs['pl_DM_noise']
         else:
             log.warning("No red noise, residuals already white. Returning input residuals...")
             wres = rs


### PR DESCRIPTION
I've made a small change in the utils.py function whiten_resids. The default pint_pal setup is not compatible with/doesn't know about DM red noise modeling, so you can't get nice whitened residuals plots when using DM red noise modeling. Which is a problem since you don't know about how well the DM model is working without the whitened residuals plot. 

Edits are in lines 45 and following in utils.py.