### PR TITLE
Allow markdown in compare_models

### DIFF
--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -619,7 +619,7 @@ def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=N
     log.info(f'Selecting {sum(mask)} TOAs of {fo.toas.ntoas} ({sum(c)} removed) based on large_residual() criteria.')
     return fo.toas[mask]
 
-def compare_models(fo,model_to_compare=None,verbosity='check',threshold_sigma=3.,nodmx=True):
+def compare_models(fo,model_to_compare=None,verbosity='check',threshold_sigma=3.,nodmx=True,format="text"):
     """Wrapper function to compare post-fit results to a user-specified comparison model.
 
     Parameters
@@ -634,6 +634,8 @@ def compare_models(fo,model_to_compare=None,verbosity='check',threshold_sigma=3.
         sigma cutoff for parameter comparison
     nodmx: bool, optional
         when True, omit DMX comparison
+    format: string, optional
+        "text" for plain text, "markdown" for markdown
 
     Returns
     =======
@@ -645,7 +647,7 @@ def compare_models(fo,model_to_compare=None,verbosity='check',threshold_sigma=3.
         comparemodel=models.get_model(model_to_compare)
     else:
         comparemodel=fo.model_init
-    return comparemodel.compare(fo.model,verbosity=verbosity,nodmx=nodmx,threshold_sigma=threshold_sigma)
+    return comparemodel.compare(fo.model,verbosity=verbosity,nodmx=nodmx,threshold_sigma=threshold_sigma, format=format)
 
 def remove_noise(model, noise_components=['ScaleToaError','ScaleDmError',
     'EcorrNoise','PLRedNoise']):


### PR DESCRIPTION
Allowed lite_utils.compare_models to output markdown (which is an option in the PINT f'n that underlies it).