### PR TITLE
Fix notebook kernel name

### DIFF
--- a/nb_templates/process_ipta_prenoise_v0.ipynb
+++ b/nb_templates/process_ipta_prenoise_v0.ipynb
@@ -168,9 +168,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ipta",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "ipta"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Reverts the inadvertent change in the notebook metadata made in #34 -- setting the kernel name to "ipta" causes problems in the IPTA DR3 CI environement.