### PR TITLE
Generate PDF summary instead of HTML

### DIFF
--- a/nb_templates/process_ipta_prenoise_v0.ipynb
+++ b/nb_templates/process_ipta_prenoise_v0.ipynb
@@ -147,8 +147,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Generate the HTML report\n",
-    "report.generate_html(f\"{tc.get_source()}-pint-summary.html\")"
+    "# Generate the PDF report\n",
+    "report.generate_pdf(f\"{tc.get_source()}-pint-summary.pdf\")"
    ]
   }
  ],

--- a/nb_templates/process_ipta_prenoise_v0.ipynb
+++ b/nb_templates/process_ipta_prenoise_v0.ipynb
@@ -90,10 +90,10 @@
     "# Define the fitter object and plot pre-fit residuals\n",
     "fo = tc.construct_fitter(to,mo)\n",
     "pu.plot_residuals_time(fo, restype='prefit', legend=False)\n",
-    "report.add_plot(\"Prefit residuals\", caption='Residuals vs. time')\n",
+    "report.add_plot(\"Prefit residuals\")\n",
     "if mo.is_binary:\n",
     "    pu.plot_residuals_orb(fo, restype='prefit', legend=False)\n",
-    "    report.add_plot(\"Prefit residuals\", caption='Residuals vs. orbital phase')"
+    "    report.add_plot(\"Prefit residuals\")"
    ]
   },
   {
@@ -122,10 +122,10 @@
    "source": [
     "# Plot post-fit residuals, print summary of results, write prenoise solution\n",
     "pu.plot_residuals_time(fo, restype='postfit', legend=False)\n",
-    "report.add_plot(\"Postfit residuals\", caption='Residuals vs. time')\n",
+    "report.add_plot(\"Postfit residuals\")\n",
     "if mo.is_binary:\n",
     "    pu.plot_residuals_orb(fo, restype='postfit', legend=False)\n",
-    "    report.add_plot(\"Postfit residuals\", caption='Residuals vs. orbital phase')\n",
+    "    report.add_plot(\"Postfit residuals\")\n",
     "    \n",
     "summary = fo.get_summary()\n",
     "report.add_markdown(\"Fit summary\", f\"```\\n{summary}\\n```\")\n",

--- a/src/pint_pal/report.py
+++ b/src/pint_pal/report.py
@@ -79,6 +79,7 @@ class Report:
         figure=None,
         *,
         dpi=300,
+        width=1.0,
         caption=None,
         also_display=False,
         **savefig_kwargs,
@@ -91,7 +92,7 @@ class Report:
         figure.savefig(filename, dpi=dpi, **savefig_kwargs)
         if caption is None:
             caption = filename
-        new_content = f"![{caption}]({filename}){{dpi={dpi}}}\n\n"
+        new_content = f"![{caption}]({filename}){{width={100*width:g}%}}\n\n"
         self.add_markdown(section, new_content, also_display=also_display)
 
     def generate(self, *, include_title=True):

--- a/src/pint_pal/report.py
+++ b/src/pint_pal/report.py
@@ -78,6 +78,7 @@ class Report:
         section,
         figure=None,
         *,
+        dpi=300,
         caption=None,
         also_display=False,
         **savefig_kwargs,
@@ -87,10 +88,10 @@ class Report:
         filename = self._new_figure_filename(section)
         if figure is None:
             figure = plt.gcf()
-        figure.savefig(filename, dpi=300, **savefig_kwargs)
+        figure.savefig(filename, dpi=dpi, **savefig_kwargs)
         if caption is None:
             caption = filename
-        new_content = f"![{caption}]({filename})\n\n"
+        new_content = f"![{caption}]({filename}){{dpi={dpi}}}\n\n"
         self.add_markdown(section, new_content, also_display=also_display)
 
     def generate(self, *, include_title=True):

--- a/src/pint_pal/report.py
+++ b/src/pint_pal/report.py
@@ -80,7 +80,7 @@ class Report:
         *,
         dpi=300,
         width=1.0,
-        caption=None,
+        caption="",
         also_display=False,
         **savefig_kwargs,
     ):
@@ -90,8 +90,6 @@ class Report:
         if figure is None:
             figure = plt.gcf()
         figure.savefig(filename, dpi=dpi, **savefig_kwargs)
-        if caption is None:
-            caption = filename
         new_content = f"![{caption}]({filename}){{width={100*width:g}%}}\n\n"
         self.add_markdown(section, new_content, also_display=also_display)
 


### PR DESCRIPTION
Generate the summary report as a PDF (not HTML) document. This seems to work better when exposed as an artifact through GitLab CI, and is just easier to deal with in general.