### PR TITLE
Remove par shuffler from IPTA notebook

### DIFF
--- a/nb_templates/process_ipta_prenoise_v0.ipynb
+++ b/nb_templates/process_ipta_prenoise_v0.ipynb
@@ -147,23 +147,6 @@
     "# Generate the HTML report\n",
     "report.generate_html(f\"{tc.get_source()}-pint-summary.html\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# \\[stage\\] changes in git"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Copy the new par file to the par directory and archive the old one, then stage the changes in Git.\n",
-    "pp.checkin.shuffle_pars(tc)"
-   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
It's not really doing anything useful right now. Maybe we'll want to bring it back for full DR3 and/or later datasets, so I'm leaving in the code, but taking it out of the IPTA notebook.