### PR TITLE
Fix PyPI build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pint_pal"
-version = "0.1.0"
+dynamic = ["version"]
 authors = [
   { name="Joe Glaser", email="joe.glaser@nanograv.org" },
   { name="Joe Swiggum", email="joe.swiggum@nanograv.org" },


### PR DESCRIPTION
Changes the line `version = "0.1.0"` in `pyproject.toml` to `dynamic = ["version"]`. This should keep the automatic PyPI build from failing the way it did [here](https://github.com/nanograv/pint_pal/actions/runs/5396046185/jobs/9799228046), where it built a wheel for v0.1.0 and PyPI rejected it because the version already existed.