### PR TITLE
Fix noise analysis for "narrowband" data with no ECORR

### DIFF
--- a/src/pint_pal/noise_utils.py
+++ b/src/pint_pal/noise_utils.py
@@ -303,17 +303,13 @@ def add_noise_to_model(model, burn_frac = 0.25, save_corner = True, no_corner_pl
         dmefac_params = []
         dmequad_params = []
 
-    ii = 0
-    idx = 0
+    efac_idx = 1
+    equad_idx = 1
+    ecorr_idx = 1
+    dmefac_idx = 1
+    dmequad_idx = 1
 
     for key, val in wn_dict.items():
-
-        if not using_wideband:
-            if ii % 3 == 0:
-                idx += 1
-        else:
-            if ii % 5 == 0:
-                idx += 1
 
         psr_name = key.split('_')[0]
 
@@ -321,9 +317,10 @@ def add_noise_to_model(model, burn_frac = 0.25, save_corner = True, no_corner_pl
 
             param_name = key.split('_efac')[0].split(psr_name)[1][1:]
 
-            tp = maskParameter(name = 'EFAC', index = idx, key = '-f', key_value = param_name,
+            tp = maskParameter(name = 'EFAC', index = efac_idx, key = '-f', key_value = param_name,
                                value = val, units = '')
             efac_params.append(tp)
+            efac_idx += 1
 
         # See https://github.com/nanograv/enterprise/releases/tag/v3.3.0
         # ..._t2equad uses PINT/Tempo2/Tempo convention, resulting in total variance EFAC^2 x (toaerr^2 + EQUAD^2)
@@ -331,53 +328,57 @@ def add_noise_to_model(model, burn_frac = 0.25, save_corner = True, no_corner_pl
 
             param_name = key.split('_t2equad')[0].split(psr_name)[1].split('_log10')[0][1:]
 
-            tp = maskParameter(name = 'EQUAD', index = idx, key = '-f', key_value = param_name,
+            tp = maskParameter(name = 'EQUAD', index = equad_idx, key = '-f', key_value = param_name,
                                value = 10 ** val / 1e-6, units = 'us')
             equad_params.append(tp)
+            equad_idx += 1
 
         # ..._tnequad uses temponest convention, resulting in total variance EFAC^2 toaerr^2 + EQUAD^2
         elif '_tnequad' in key:
 
             param_name = key.split('_tnequad')[0].split(psr_name)[1].split('_log10')[0][1:]
 
-            tp = maskParameter(name = 'EQUAD', index = idx, key = '-f', key_value = param_name,
+            tp = maskParameter(name = 'EQUAD', index = equad_idx, key = '-f', key_value = param_name,
                                value = 10 ** val / 1e-6, units = 'us')
             equad_params.append(tp)
+            equad_idx += 1
 
         # ..._equad uses temponest convention; generated with enterprise pre-v3.3.0
         elif '_equad' in key:
 
             param_name = key.split('_equad')[0].split(psr_name)[1].split('_log10')[0][1:]
 
-            tp = maskParameter(name = 'EQUAD', index = idx, key = '-f', key_value = param_name,
+            tp = maskParameter(name = 'EQUAD', index = equad_idx, key = '-f', key_value = param_name,
                                value = 10 ** val / 1e-6, units = 'us')
             equad_params.append(tp)
+            equad_idx += 1
 
         elif ('_ecorr' in key) and (not using_wideband):
 
             param_name = key.split('_ecorr')[0].split(psr_name)[1].split('_log10')[0][1:]
 
-            tp = maskParameter(name = 'ECORR', index = idx, key = '-f', key_value = param_name,
+            tp = maskParameter(name = 'ECORR', index = ecorr_idx, key = '-f', key_value = param_name,
                                value = 10 ** val / 1e-6, units = 'us')
             ecorr_params.append(tp)
+            ecorr_idx += 1
 
         elif ('_dmefac' in key) and (using_wideband):
 
             param_name = key.split('_dmefac')[0].split(psr_name)[1][1:]
 
-            tp = maskParameter(name = 'DMEFAC', index = idx, key = '-f', key_value = param_name,
+            tp = maskParameter(name = 'DMEFAC', index = dmefac_idx, key = '-f', key_value = param_name,
                                value = val, units = '')
             dmefac_params.append(tp)
+            dmefac_idx += 1
 
         elif ('_dmequad' in key) and (using_wideband):
 
             param_name = key.split('_dmequad')[0].split(psr_name)[1].split('_log10')[0][1:]
 
-            tp = maskParameter(name = 'DMEQUAD', index = idx, key = '-f', key_value = param_name,
+            tp = maskParameter(name = 'DMEQUAD', index = dmequad_idx, key = '-f', key_value = param_name,
                                value = 10 ** val, units = 'pc/cm3')
             dmequad_params.append(tp)
-
-        ii += 1
+            dmequad_idx += 1
 
     # Test EQUAD convention and decide whether to convert
     convert_equad_to_t2 = False


### PR DESCRIPTION
In trying to run the `process_v1.2` notebook on simulated LOFAR data, @FrancescoIraci ran into an issue (#44) where `noise_utils.add_noise_to_model()` would raise an exception if "narrowband" data didn't have associated ECORR parameters.

It turns out that this function was written in an unnecessarily inflexible way: with `using_wideband = False`, it would always try to add ECORR parameters to the model, whether or not they were present in the white noise dictionary returned by `noise_utils.analyze_noise()`. In this case, not finding any, it would raise an exception. (Similarly, with `using_wideband = True`, it would always try to add DMEFAC and DMEQUAD parameters, even if none were present.)

This PR changes this behavior to make it more flexible: now, ECORR, DMEFAC, and DMEQUAD parameters should be added if, and only if, they are present in the white noise dictionary, regardless of the value of `using_wideband`, which now only serves to identify the appropriate noise chain directory. This should make it possible to run the notebook on narrowband data without EFAC, or on wideband data without DMEFAC and/or DMEQUAD.