### PR TITLE
Update CI to use Official miniconda actions.

### DIFF
--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -30,12 +30,11 @@ jobs:
           mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
-          activate-environment: pulsar
     - name: Install Dependencies & Main Code
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-        mamba install -c conda-forge cython=0.29.36 tempo2 scikit-sparse
+        mamba install -c conda-forge python=${{ matrix.python-version }} cython=0.29.36 tempo2 scikit-sparse
         python -m pip install -e .
     - name: Test with Standard Pulsar
       run: |

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v2
-        with:
+      with:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
           channels: conda-forge,defaults
@@ -35,7 +35,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-        mamba install -c conda-forge tempo2 scikit-sparse<3.0
+        mamba install -c conda-forge cython<=0.29.36 tempo2 scikit-sparse
         python -m pip install -e .
     - name: Test with Standard Pulsar
       run: |

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-        mamba install -c conda-forge cython<=0.29.36 tempo2 scikit-sparse
+        mamba install -c conda-forge cython=0.29.36 tempo2 scikit-sparse
         python -m pip install -e .
     - name: Test with Standard Pulsar
       run: |

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - name: Install pdflatex
@@ -35,9 +35,7 @@ jobs:
     - name: Install Dependencies & Main Code
       shell: bash -el {0}
       run: |
-        pip install --upgrade pip
-        pip install pytest
-        mamba install -c conda-forge python=${{ matrix.python-version }} cython=0.29.36 tempo2 enterprise-pulsar enterprise_extensions scikit-sparse
+        mamba install -c conda-forge python=${{ matrix.python-version }} pytest cython=0.29.36 tempo2 enterprise-pulsar enterprise_extensions scikit-sparse
         pip install -e .
     - name: Test with Standard Pulsar
       shell: bash -el {0}

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install pytest
-        mamba install -c conda-forge python=${{ matrix.python-version }} cython=0.29.36 tempo2 scikit-sparse
+        mamba install -c conda-forge python=${{ matrix.python-version }} cython=0.29.36 tempo2 enterprise enterprise_extensions scikit-sparse
         pip install -e .
     - name: Test with Standard Pulsar
       shell: bash -el {0}

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - name: Install pdflatex
@@ -24,19 +24,18 @@ jobs:
         sudo apt-get install texlive-latex-base pdftk latex2html
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Add Conda to System Path & Install Mamba
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-        conda install -c conda-forge mamba
+      uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
+          activate-environment: pulsar
     - name: Install Dependencies & Main Code
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-        mamba install -c conda-forge tempo2 scikit-sparse
+        mamba install -c conda-forge tempo2 scikit-sparse<3.0
         python -m pip install -e .
     - name: Test with Standard Pulsar
       run: |

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install pytest
-        mamba install -c conda-forge python=${{ matrix.python-version }} cython=0.29.36 tempo2 enterprise enterprise_extensions scikit-sparse
+        mamba install -c conda-forge python=${{ matrix.python-version }} cython=0.29.36 tempo2 enterprise-pulsar enterprise_extensions scikit-sparse
         pip install -e .
     - name: Test with Standard Pulsar
       shell: bash -el {0}

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8"]
 
     steps:
     - name: Install pdflatex
@@ -23,8 +23,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install texlive-latex-base pdftk latex2html
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v2
       with:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
@@ -32,10 +31,10 @@ jobs:
           channel-priority: true
     - name: Install Dependencies & Main Code
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest
+        pip install --upgrade pip
+        pip install pytest
         mamba install -c conda-forge python=${{ matrix.python-version }} cython=0.29.36 tempo2 scikit-sparse
-        python -m pip install -e .
+        pip install -e .
     - name: Test with Standard Pulsar
       run: |
         export PULSAR_NAME='J0605+3757'

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -29,13 +29,18 @@ jobs:
           mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
+    - name: Conda info
+      shell: bash -el {0}
+      run: conda info
     - name: Install Dependencies & Main Code
+      shell: bash -el {0}
       run: |
         pip install --upgrade pip
         pip install pytest
         mamba install -c conda-forge python=${{ matrix.python-version }} cython=0.29.36 tempo2 scikit-sparse
         pip install -e .
     - name: Test with Standard Pulsar
+      shell: bash -el {0}
       run: |
         export PULSAR_NAME='J0605+3757'
         export JUPYTER_PLATFORM_DIRS=1 && jupyter --paths

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - name: Install pdflatex


### PR DESCRIPTION
This is an MR to replace our previous method of creating python environments with the conda-incubator system which should pin the python version correctly in tests.