### PR TITLE
Be more robust to missing flags

### DIFF
--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -710,7 +710,7 @@ class TimingConfiguration:
         # All info here about selecting various TOAs.
         # Select TOAs to cut, then use apply_cut_flag.
         if 'orphaned-rec' in valid_valued:
-            fs = np.array([f['f'] for f in toas.orig_table['flags']])
+            fs = np.array([(f['f'] if 'f' in f else None) for f in toas.orig_table['flags']])
             for o in self.get_orphaned_rec():
                 orphinds = np.where(fs==o)[0]
                 apply_cut_flag(toas,orphinds,'orphaned',warn=warn)
@@ -723,7 +723,9 @@ class TimingConfiguration:
             endinds = np.where(mjds > self.get_mjd_end())[0]
             apply_cut_flag(toas,endinds,'mjdend',warn=warn)
         if 'snr-cut' in valid_valued:
-            snrs = np.array([float(f['snr']) for f in toas.orig_table['flags']])
+            if any('snr' not in f for f in toas.orig_table['flags']):
+                log.warning("Excision key 'snr-cut' in use, but some TOAs are missing the 'snr' flag.")
+            snrs = np.array([(float(f['snr']) if 'snr' in f else np.nan) for f in toas.orig_table['flags']])
             snrinds = np.where(snrs < self.get_snr_cut())[0]
             apply_cut_flag(toas,snrinds,'snr',warn=warn)
             if self.get_snr_cut() > 8.0 and self.get_toa_type() == 'NB':
@@ -731,7 +733,7 @@ class TimingConfiguration:
             if self.get_snr_cut() > 25.0 and self.get_toa_type() == 'WB':
                 log.warning('snr-cut should be set to 25; try excising TOAs using other methods.')
         if 'poor-febe' in valid_valued:
-            fs = np.array([f['f'] for f in toas.orig_table['flags']])
+            fs = np.array([(f['f'] if 'f' in f else None) in toas.orig_table['flags']])
             for febe in self.get_poor_febes():
                 febeinds = np.where(fs==febe)[0]
                 apply_cut_flag(toas,febeinds,'poorfebe',warn=warn)
@@ -788,7 +790,7 @@ class TimingConfiguration:
                 log.warning(f'One or more bad-file entries lack reasons for excision; please add them.')
         if 'bad-range' in valid_valued:
             mjds = np.array([m for m in toas.orig_table['mjd_float']])
-            backends = np.array([f['be'] for f in toas.orig_table['flags']])
+            backends = np.array([(f['be'] if 'be' in f else None) for f in toas.orig_table['flags']])
             for br in self.get_bad_ranges():
                 if len(br) > 2:
                     rangeinds = np.where((mjds>br[0]) & (mjds<br[1]) & (backends==br[2]))[0]
@@ -808,8 +810,9 @@ class TimingConfiguration:
         if 'bad-toa' in valid_valued:
             logwarntoa = False
             names = np.array([f['name'] for f in toas.orig_table['flags']])
-            subints = np.array([int(f['subint']) for f in toas.orig_table['flags']])
-            if self.get_toa_type() == 'NB': chans = np.array([int(f['chan']) for f in toas.orig_table['flags']])
+            subints = np.array([(int(f['subint']) if 'subint' in f else None) for f in toas.orig_table['flags']])
+            if self.get_toa_type() == 'NB':
+                chans = np.array([(int(f['chan']) if 'chan' in f else None) for f in toas.orig_table['flags']])
             btinds = []
             for bt in self.get_bad_toas():
                 if len(bt) < 4: logwarntoa = True


### PR DESCRIPTION
Changes `TimingConfiguration.apply_ignore()` so that, when matching TOAs against excision criteria, any TOAs where the relevant flags are missing will be left alone. This applies to:
- `orphaned-rec` (`-f` flag)
- `snr-cut` (`-snr` flag -- will now log a warning if this is missing from any TOAs, but proceed anyway)
- `poor-febe` (`-f` flag)
- `bad-range` (`-be` flag)
- `bad-toa` (`-subint` and `-chan` flags).

With these changes, it should be possible to use the above excision keys even when some TOAs are missing the associated flags, which should help with cases like what @gooddc saw in #47.