### PR TITLE
Correctly whiten residuals with DM noise

### DIFF
--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -73,8 +73,12 @@ def whiten_resids(fitter, restype = 'postfit'):
             # Get number of residuals
         num_res = len(time_resids)
         # Check that the key is in the dictionary
-        if "pl_red_noise" in noise_resids:
+        if "pl_red_noise" and "pl_DM_noise" in noise_resids:
+            wres = time_resids - noise_resids['pl_red_noise'][:num_res] - noise_resids['pl_DM_noise'][:num_res]
+        elif "pl_red_noise" in noise_resids:
             wres = time_resids - noise_resids['pl_red_noise'][:num_res]
+        elif "pl_DM_noise" in noise_resids:
+            wres = time_resids - noise_resids['pl_DM_noise'][:num_res]
         else:
             log.warning("No red noise, residuals already white. Returning input residuals...")
             wres = time_resids


### PR DESCRIPTION
In experimenting with whitened residual plots, I found that `plot_utils.plot_resids_time()` with `whitened=True` would only correctly remove DM noise described by a `PLDMNoise` component (par file parameters `TNDMAMP`/`TNDMGAM`/`TNDMC`) in certain cases (more or less only if the residuals were first averaged). This should fix that, so that the DM noise is always removed when `whitened=True`, as intended.