### PR TITLE
Fix bug in `pdf_writer()` tim file listing

### DIFF
--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -566,7 +566,11 @@ def pdf_writer(fitter,
     # print list of tim file names, limit two tim files per line
     fsum.write(r'Input tim files:' + "\n")
     fsum.write(r'\begin{itemize}' + "\n")
-    for tf in fitter.toas.filename:
+    if isinstance(fitter.toas.filename, str):
+        tim_files = [fitter.toas.filename]
+    else:
+        tim_files = fitter.toas.filename
+    for tf in tim_files:
         fsum.write(r'\item ' + verb(tf.split('/')[-1]) + '\n')
     fsum.write(r'\end{itemize}' + "\n")
     fsum.write('Span: %.1f years (%.1f -- %.1f)\\\\\n ' % (span/365.24,


### PR DESCRIPTION
In printing the list of tim filenames, the PDF writer code [here](https://github.com/nanograv/pint_pal/blob/478b895bf5f692ab098f7ef7fd5310368e3a2440/src/pint_pal/utils.py#L569) loops over `toas.filename`. The problem with this is, the `filename` attribute of a PINT `TOAs` object might be either a string or a list of strings. Currently, only the list case is handled correctly -- if `filename` is a string, each character will be printed on a separate line. This PR updates the PDF writer code to correctly handle either case.

This problem was hidden until recently, because, until recent updates to PINT changed things, the way that `TimingConfiguration.get_model_and_toas()` constructed a TOAs object guaranteed that its `filename` attribute would be a list, not a string. However, since nanograv/PINT#1593 was merged, `filename` is always a string if there is only file associated with the `TOAs` object.