### PR TITLE
Add PINT autofitter option

### DIFF
--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -336,8 +336,11 @@ class TimingConfiguration:
     def construct_fitter(self, to, mo):
         """ Return the fitter, tracking pulse numbers if available """
         fitter_name = self.config['fitter']
-        fitter_class = getattr(pint.fitter, fitter_name)
-        return fitter_class(to, mo)
+        if fitter_name == 'Auto':
+            return pint.fitter.Fitter.auto(to, mo)
+        else:
+            fitter_class = getattr(pint.fitter, fitter_name)
+            return fitter_class(to, mo)
 
     def get_toa_type(self):
         """ Return the toa-type string """


### PR DESCRIPTION
PINT does a good job of picking the best fitter automatically. You can still specify the specific fitter (e.g. `DownhillGLSFitter`) in the YAML `fitter` key, but this lets you also specify `Auto` instead. (I know the `else` doesn't need to be there but I feel like it's clearer to read?)