### PR TITLE
Also run tests on pull requests targeting the NG20 branch

### DIFF
--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: 
       - main
+      - NG20
 
 jobs:
   build:

--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -336,8 +336,11 @@ class TimingConfiguration:
     def construct_fitter(self, to, mo):
         """ Return the fitter, tracking pulse numbers if available """
         fitter_name = self.config['fitter']
-        fitter_class = getattr(pint.fitter, fitter_name)
-        return fitter_class(to, mo)
+        if fitter_name == 'Auto':
+            return pint.fitter.Fitter.auto(to, mo)
+        else:
+            fitter_class = getattr(pint.fitter, fitter_name)
+            return fitter_class(to, mo)
 
     def get_toa_type(self):
         """ Return the toa-type string """


### PR DESCRIPTION
Currently, the GitHub Actions configuration is set to run tests only for PRs that target the `main` branch. This changes that, so that tests should also run on PRs that target the `NG20` branch.