### PR TITLE
Also run tests on PRs targeting NG20 branch

### DIFF
--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: 
       - main
+      - NG20
 
 jobs:
   build:


### PR DESCRIPTION
Currently, the GitHub Actions configuration is set to run tests only for PRs that target the main branch. This changes that, so that tests should also run on PRs that target the NG20 branch. (New version that targets the correct branch!)