### PR TITLE
Fix for excise-tim being present but unset

### DIFF
--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -359,7 +359,7 @@ class TimingConfiguration:
 
     def get_excised(self):
         """ Return excised-tim file if set and exists"""
-        if 'excised-tim' in self.config['intermediate-results'].keys():
+        if 'excised-tim' in self.config['intermediate-results'].keys() and self.config['intermediate-results']['excised-tim']:
             if os.path.exists(self.config['intermediate-results']['excised-tim']):
                 return self.config['intermediate-results']['excised-tim']
         return None


### PR DESCRIPTION
Before things were fine as long as excise-tim was a string, but if it was None, it died. Now it checks to make sure it's actually set before doing the os path check. 