### PR TITLE
Large Residuals feature proposal: Find Potential Bad Jump Flags

### DIFF
--- a/src/pint_pal/PINT_parameters.py
+++ b/src/pint_pal/PINT_parameters.py
@@ -6,7 +6,7 @@ from pint import ls
 This file will be a list of pre-defined PINT parameters and components to be used for F-tests.
 Current parameters to be listed:
 
-PX, PMLABMDA, PMBETA, PMRA, PMDEC, H3, H4, K96, M2, SINI, PBDOT, XDOT, EPS1DOT, EPS2DOT, OMDOT, EDOT, FBX, FDX, F1, F2, F3
+PX, PMLAMBDA, PMBETA, PMRA, PMDEC, H3, H4, K96, M2, SINI, PBDOT, XDOT, EPS1DOT, EPS2DOT, OMDOT, EDOT, FBX, FDX, F1, F2, F3
 
 TO DO: Check units, check parameters/components are appropriately set for different binary models.
 -> May want to manually add the binary model prefix to each parameter appropriately e.g. component = 'BINARY', add 'DD' before F-Test.
@@ -38,36 +38,41 @@ PX = p.floatParameter(parameter_type="float",
     name="PX",
     value=0.0,
     units=u.mas,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 PX_Component = 'AstrometryEcliptic'
 
 # Proper Motion
-PMLABMDA = p.floatParameter(parameter_type="float",
-    name="PMLABMDA",
+PMLAMBDA = p.floatParameter(parameter_type="float",
+    name="PMLAMBDA",
     value=0.0,
     units=u.mas/u.yr,
-    frozen = False)
-PMLAMDA_Component = 'AstrometryEcliptic'
+    frozen = False,
+    convert_tcb2tdb=False)
+PMLAMBDA_Component = 'AstrometryEcliptic'
 
 PMBETA = p.floatParameter(parameter_type="float",
     name="PMBETA",
     value=0.0,
     units=u.mas/u.yr,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 PMBETA_Component = 'AstrometryEcliptic'
 
 PMRA = p.floatParameter(parameter_type="float",
     name="PMRA",
     value=0.0,
     units=u.mas/u.yr,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 PMRA_Component = 'AstrometryEcliptic'
 
 PMDEC = p.floatParameter(parameter_type="float",
     name="PMDEC",
     value=0.0,
     units=u.mas/u.yr,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 PMDEC_Component = 'AstrometryEcliptic'
 
 # H3 and H4
@@ -75,20 +80,23 @@ H3 = p.floatParameter(parameter_type="float",
     name="H3",
     value=0.0,
     units=u.s,
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 H3_Component = 'Binary'
 
 H4 = p.floatParameter(parameter_type="float",
     name="H4",
     value=0.0,
     units=u.s,
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 H4_Component = 'Binary'
 
 # K96, turns on flag for Kopeikin binary model proper motion correction
 K96 = p.prefixParameter(parameter_type="bool",
     name="K96",
-    value=True)
+    value=True,
+    convert_tcb2tdb=False)
 K96_Component = 'Binary'
 
 # M2 and SINI -> check units
@@ -96,14 +104,16 @@ M2 = p.floatParameter(parameter_type="float",
     name="M2",
     value=0.25,
     units=u.solMass,
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 M2_Component = 'Binary'
 
 SINI = p.floatParameter(parameter_type="float",
     name="SINI",
     value=0.8,
     units="",
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 SINI_Component = 'Binary'
 
 # PBDOT
@@ -111,7 +121,8 @@ PBDOT = p.floatParameter(parameter_type="float",
     name="PBDOT",
     value=0.0,
     units="",
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 PBDOT_Component = 'Binary'
 
 # XDOT
@@ -119,7 +130,8 @@ XDOT = p.floatParameter(parameter_type="float",
     name="XDOT",
     value=0.0,
     units="",
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 XDOT_Component = 'Binary'
 
 # A1DOT
@@ -127,7 +139,8 @@ A1DOT = p.floatParameter(parameter_type="float",
     name="A1DOT",
     value=0.0,
     units= ls / u.second,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 A1DOT_Component = 'Binary'
 
 #EPS1DOT and EPS2DOT
@@ -135,14 +148,16 @@ EPS1DOT = p.floatParameter(parameter_type="float",
     name="EPS1DOT",
     value=0.0,
     units=1e-12/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 EPS1DOT_Component = 'Binary'
 
 EPS2DOT = p.floatParameter(parameter_type="float",
     name="EPS2DOT",
     value=0.0,
     units=1e-12/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 EPS2DOT_Component = 'Binary'
 
 # OMDOT
@@ -150,7 +165,8 @@ OMDOT = p.floatParameter(parameter_type="float",
     name="OMDOT",
     value=0.0,
     units=(u.deg/u.year),
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 OMDOT_Component = 'Binary'
 
 # EDOT
@@ -158,7 +174,8 @@ EDOT = p.floatParameter(parameter_type="float",
     name="EDOT",
     value=0.0,
     units=(1/u.s),
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 EDOT_Component = 'Binary'
 
 # FBX -> Do we need more? Is there a better way to do this? Check these...
@@ -166,42 +183,48 @@ FB0 = p.prefixParameter(parameter_type="float",
     name="FB0",
     value=0.0,
     units=1/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB0_Component = 'Binary'
 
 FB1 = p.prefixParameter(parameter_type="float",
     name="FB1",
     value=0.0,
     units=1/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB1_Component = 'Binary'
 
 FB2 = p.prefixParameter(parameter_type="float",
     name="FB2",
     value=0.0,
     units=1/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB2_Component = 'Binary'
 
 FB3 = p.prefixParameter(parameter_type="float",
     name="FB3",
     value=0.0,
     units=1/u.s/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB3_Component = 'Binary'
 
 FB4 = p.prefixParameter(parameter_type="float",
     name="FB4",
     value=0.0,
     units=1/u.s/u.s/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB4_Component = 'Binary'
 
 FB5 = p.prefixParameter(parameter_type="float",
     name="FB5",
     value=0.0,
     units=1/u.s/u.s/u.s/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB5_Component = 'Binary'
 
 # FDX -> Do we need more? Is there a better way to do this?
@@ -209,42 +232,48 @@ FD1 = p.prefixParameter(parameter_type="float",
     name="FD1",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD1_Component = 'FD'
 
 FD2 = p.prefixParameter(parameter_type="float",
     name="FD2",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD2_Component = 'FD'
 
 FD3 = p.prefixParameter(parameter_type="float",
     name="FD3",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD3_Component = 'FD'
 
 FD4 = p.prefixParameter(parameter_type="float",
     name="FD4",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD4_Component = 'FD'
 
 FD5 = p.prefixParameter(parameter_type="float",
     name="FD5",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD5_Component = 'FD'
 
 FD6 = p.prefixParameter(parameter_type="float",
     name="FD6",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD6_Component = 'FD'
 
 # FX, spindown derivatives
@@ -252,19 +281,22 @@ F1 = p.prefixParameter(parameter_type="float",
     name="F1",
     value=0.0,
     units=u.Hz/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 F1_Component = 'Spindown'
 
 F2 = p.prefixParameter(parameter_type="float",
     name="F2",
     value=0.0,
     units=u.Hz/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 F2_Component = 'Spindown'
 
 F3 = p.prefixParameter(parameter_type="float",
     name="F3",
     value=0.0,
     units=u.Hz/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 F3_Component = 'Spindown'

--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -608,11 +608,6 @@ def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=N
     else:
         c = c_toa
 
-    badlist = np.where(c)
-    names = fo.toas.get_flag_value('name')[0]
-    chans = fo.toas.get_flag_value('chan')[0]
-    subints = fo.toas.get_flag_value('subint')[0]
-
     if find_jump_flags:
         bad_length = sum(~c)
         jump_flag_names = ['pta', 'h', 'g', 'j', 'f', 'group', 'fe', 'sys',
@@ -635,6 +630,10 @@ def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=N
         print("\n Large Residual TOAs:")
 
     if print_bad:
+        badlist = np.where(c)
+        names = fo.toas.get_flag_value('name')[0]
+        chans = fo.toas.get_flag_value('chan')[0]
+        subints = fo.toas.get_flag_value('subint')[0]
         for ibad in badlist[0]:
             name = names[ibad]
             chan = chans[ibad]

--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -611,7 +611,7 @@ def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=N
     badlist = np.where(c)
     good_list = np.where(~c)
     
-    if find_jump_flags:
+    if check_jumps:
         bad_length = sum(c)
         jump_flag_names = ['pta', 'sys', 'fe', 'h', 'g', 'j', 'f', 'group',
                             'medusa_59200_jump', 'medusa_58925_jump']

--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -532,7 +532,7 @@ def add_flag_jumps(mo,flag,flaglist,base=False):
                 JUMPn = maskParameter('JUMP',key=flagval,key_value=[j],value=0.0,units=u.second)
                 phasejump.add_param(JUMPn,setup=True)
 
-def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=None,prefit=False,ignore_ASP_dms=True,print_bad=True, find_jump_flags=False):
+def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=None,prefit=False,ignore_ASP_dms=True,print_bad=True, check_jumps=False):
     """Quick and dirty routine to find outlier residuals based on some threshold.
     Automatically deals with Wideband vs. Narrowband fitters.
 
@@ -553,8 +553,8 @@ def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=N
         If True, it will not flag/excise any TOAs from ASP or GASP data based on DM criteria
     print_bad: bool
         If True, prints bad-toa lines that can be copied directly into a yaml file
-    find_jump_flags: bool
-        If True, prints a list of potential Jump flags that only appear in the toas with large residuals, alongside the percent of such toas that share that flag.
+    check_jumps: bool
+        If True, prints a list of likely and potential Jump flags that appear in the toas with large residuals, alongside the percent of such toas from each PTA that share that flag.
 
     Returns
     =======
@@ -609,26 +609,59 @@ def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=N
         c = c_toa
 
     badlist = np.where(c)
+    good_list = np.where(~c)
     
     if find_jump_flags:
-        bad_length = sum(~c)
-        jump_flag_names = ['pta', 'h', 'g', 'j', 'f', 'group', 'fe', 'sys',
+        bad_length = sum(c)
+        jump_flag_names = ['pta', 'sys', 'fe', 'h', 'g', 'j', 'f', 'group',
                             'medusa_59200_jump', 'medusa_58925_jump']
+        pta_flags = [['sys'],['sys'],['pta'],['fe'],
+                     ['h', 'g', 'j', 'f', 'group','medusa_59200_jump', 'medusa_58925_jump']]
+        pta_nums = {'EPTA':0, 'InPTA':1, 'MPTA':2, 'NANOGrav':3, 'PPTA':4}
+        pta_names = ['EPTA', 'InPTA', 'MPTA', 'NANOGrav', 'PPTA']
+        pta_toas = [0,0,0,0,0]
         bad_jump_flags = {}
-        for flag in jump_flag_names:
-            flag_values = fo.toas.get_flag_value(flag)[0]
-            for ibad in badlist[0]:
-                if flag_values[ibad] != None:
-                    key = '-' + flag + ' ' + flag_values[ibad]
+        dubious_jump_flags = {}
+        
+        flag_values = []
+        for i1 in range(len(jump_flag_names)):
+            flag_values.append(fo.toas.get_flag_value(jump_flag_names[i1])[0])
+
+        for ibad in badlist[0]:
+            pta = flag_values[0][ibad]
+            pta_num = pta_nums[pta]
+            for i1 in range(len(jump_flag_names)):
+                flag = jump_flag_names[i1]
+                if (flag in pta_flags[pta_num]) and (flag_values[i1][ibad] != None):
+                    key = '({}) -'.format(pta) + flag + ' ' + flag_values[i1][ibad]
                     if key not in bad_jump_flags.keys():
                         bad_jump_flags[key] = 0
                     bad_jump_flags[key] += 1
+                    pta_toas[pta_num] += 1
+
+        for i1 in range(len(jump_flag_names)):
+            flag = jump_flag_names[i1]
+            for igood in good_list[0]:
+                pta = flag_values[0][igood]
+                if flag_values[i1][igood] != None:
+                    key = '({}) -'.format(pta) + flag + ' ' + flag_values[i1][igood]
+                    if key in bad_jump_flags.keys():
+                        dubious_jump_flags[key] = bad_jump_flags[key]
+                        bad_jump_flags.pop(key)
 
         likely_flags = sorted(bad_jump_flags.items(), reverse=True, key=lambda item: item[1])
-        print("Jumps you might be missing and their percent coverage: ")
+        possible_flags = sorted(dubious_jump_flags.items(), reverse=True, key=lambda item: item[1])
+        print("Jumps that are likely improperly fit: ")
         for likely_flag in likely_flags:
-            if likely_flag[1] <= bad_length:
-                print(likely_flag[0] + ': {:.2f}'.format(100 * (likely_flag[1] / bad_length)) + "%")
+            if (likely_flag[1] > 0) and (likely_flag[1] <= bad_length):
+                pta_num = pta_nums[likely_flag[0].split(')')[0][1:]]
+                print(likely_flag[0] + ': {:.2f}'.format(100 * (likely_flag[1] / pta_toas[pta_num])) + "%")
+        
+        if len(possible_flags) != 0:
+            print("\nJumps that are possibly improperly fit: ")
+        for possible_flag in possible_flags:
+            pta_num = pta_nums[possible_flag[0].split(')')[0][1:]]
+            print(possible_flag[0] + ': {:.2f}'.format(100 * (possible_flag[1] / pta_toas[pta_num])) + "%")
         print("\n Large Residual TOAs:")
 
     if print_bad:

--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -532,7 +532,7 @@ def add_flag_jumps(mo,flag,flaglist,base=False):
                 JUMPn = maskParameter('JUMP',key=flagval,key_value=[j],value=0.0,units=u.second)
                 phasejump.add_param(JUMPn,setup=True)
 
-def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=None,prefit=False,ignore_ASP_dms=True,print_bad=True, find_jump_flags=True):
+def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=None,prefit=False,ignore_ASP_dms=True,print_bad=True, find_jump_flags=False):
     """Quick and dirty routine to find outlier residuals based on some threshold.
     Automatically deals with Wideband vs. Narrowband fitters.
 

--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -608,6 +608,8 @@ def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=N
     else:
         c = c_toa
 
+    badlist = np.where(c)
+    
     if find_jump_flags:
         bad_length = sum(~c)
         jump_flag_names = ['pta', 'h', 'g', 'j', 'f', 'group', 'fe', 'sys',
@@ -630,7 +632,6 @@ def large_residuals(fo,threshold_us,threshold_dm=None,*,n_sigma=None,max_sigma=N
         print("\n Large Residual TOAs:")
 
     if print_bad:
-        badlist = np.where(c)
         names = fo.toas.get_flag_value('name')[0]
         chans = fo.toas.get_flag_value('chan')[0]
         subints = fo.toas.get_flag_value('subint')[0]


### PR DESCRIPTION
Adds an option to large_residuals() that can print a list of potential Jump flags that only appear in the toas with large residuals, alongside the percent of such toas that share that flag. The goal of this feature is to make troubleshooting combinations easier. This PR also includes a change to the print_bad implementation that checks the print_bad boolean before finding toa names.