### PR TITLE
Added convert_tcb2tdb=False to all parameters

### DIFF
--- a/src/pint_pal/PINT_parameters.py
+++ b/src/pint_pal/PINT_parameters.py
@@ -6,7 +6,7 @@ from pint import ls
 This file will be a list of pre-defined PINT parameters and components to be used for F-tests.
 Current parameters to be listed:
 
-PX, PMLABMDA, PMBETA, PMRA, PMDEC, H3, H4, K96, M2, SINI, PBDOT, XDOT, EPS1DOT, EPS2DOT, OMDOT, EDOT, FBX, FDX, F1, F2, F3
+PX, PMLAMBDA, PMBETA, PMRA, PMDEC, H3, H4, K96, M2, SINI, PBDOT, XDOT, EPS1DOT, EPS2DOT, OMDOT, EDOT, FBX, FDX, F1, F2, F3
 
 TO DO: Check units, check parameters/components are appropriately set for different binary models.
 -> May want to manually add the binary model prefix to each parameter appropriately e.g. component = 'BINARY', add 'DD' before F-Test.
@@ -38,36 +38,41 @@ PX = p.floatParameter(parameter_type="float",
     name="PX",
     value=0.0,
     units=u.mas,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 PX_Component = 'AstrometryEcliptic'
 
 # Proper Motion
-PMLABMDA = p.floatParameter(parameter_type="float",
-    name="PMLABMDA",
+PMLAMBDA = p.floatParameter(parameter_type="float",
+    name="PMLAMBDA",
     value=0.0,
     units=u.mas/u.yr,
-    frozen = False)
-PMLAMDA_Component = 'AstrometryEcliptic'
+    frozen = False,
+    convert_tcb2tdb=False)
+PMLAMBDA_Component = 'AstrometryEcliptic'
 
 PMBETA = p.floatParameter(parameter_type="float",
     name="PMBETA",
     value=0.0,
     units=u.mas/u.yr,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 PMBETA_Component = 'AstrometryEcliptic'
 
 PMRA = p.floatParameter(parameter_type="float",
     name="PMRA",
     value=0.0,
     units=u.mas/u.yr,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 PMRA_Component = 'AstrometryEcliptic'
 
 PMDEC = p.floatParameter(parameter_type="float",
     name="PMDEC",
     value=0.0,
     units=u.mas/u.yr,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 PMDEC_Component = 'AstrometryEcliptic'
 
 # H3 and H4
@@ -75,20 +80,23 @@ H3 = p.floatParameter(parameter_type="float",
     name="H3",
     value=0.0,
     units=u.s,
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 H3_Component = 'Binary'
 
 H4 = p.floatParameter(parameter_type="float",
     name="H4",
     value=0.0,
     units=u.s,
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 H4_Component = 'Binary'
 
 # K96, turns on flag for Kopeikin binary model proper motion correction
 K96 = p.prefixParameter(parameter_type="bool",
     name="K96",
-    value=True)
+    value=True,
+    convert_tcb2tdb=False)
 K96_Component = 'Binary'
 
 # M2 and SINI -> check units
@@ -96,14 +104,16 @@ M2 = p.floatParameter(parameter_type="float",
     name="M2",
     value=0.25,
     units=u.solMass,
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 M2_Component = 'Binary'
 
 SINI = p.floatParameter(parameter_type="float",
     name="SINI",
     value=0.8,
     units="",
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 SINI_Component = 'Binary'
 
 # PBDOT
@@ -111,7 +121,8 @@ PBDOT = p.floatParameter(parameter_type="float",
     name="PBDOT",
     value=0.0,
     units="",
-    frozen=False)
+    frozen=False,
+    convert_tcb2tdb=False)
 PBDOT_Component = 'Binary'
 
 # XDOT
@@ -119,7 +130,8 @@ XDOT = p.floatParameter(parameter_type="float",
     name="XDOT",
     value=0.0,
     units="",
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 XDOT_Component = 'Binary'
 
 # A1DOT
@@ -127,7 +139,8 @@ A1DOT = p.floatParameter(parameter_type="float",
     name="A1DOT",
     value=0.0,
     units= ls / u.second,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 A1DOT_Component = 'Binary'
 
 #EPS1DOT and EPS2DOT
@@ -135,14 +148,16 @@ EPS1DOT = p.floatParameter(parameter_type="float",
     name="EPS1DOT",
     value=0.0,
     units=1e-12/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 EPS1DOT_Component = 'Binary'
 
 EPS2DOT = p.floatParameter(parameter_type="float",
     name="EPS2DOT",
     value=0.0,
     units=1e-12/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 EPS2DOT_Component = 'Binary'
 
 # OMDOT
@@ -150,7 +165,8 @@ OMDOT = p.floatParameter(parameter_type="float",
     name="OMDOT",
     value=0.0,
     units=(u.deg/u.year),
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 OMDOT_Component = 'Binary'
 
 # EDOT
@@ -158,7 +174,8 @@ EDOT = p.floatParameter(parameter_type="float",
     name="EDOT",
     value=0.0,
     units=(1/u.s),
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 EDOT_Component = 'Binary'
 
 # FBX -> Do we need more? Is there a better way to do this? Check these...
@@ -166,42 +183,48 @@ FB0 = p.prefixParameter(parameter_type="float",
     name="FB0",
     value=0.0,
     units=1/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB0_Component = 'Binary'
 
 FB1 = p.prefixParameter(parameter_type="float",
     name="FB1",
     value=0.0,
     units=1/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB1_Component = 'Binary'
 
 FB2 = p.prefixParameter(parameter_type="float",
     name="FB2",
     value=0.0,
     units=1/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB2_Component = 'Binary'
 
 FB3 = p.prefixParameter(parameter_type="float",
     name="FB3",
     value=0.0,
     units=1/u.s/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB3_Component = 'Binary'
 
 FB4 = p.prefixParameter(parameter_type="float",
     name="FB4",
     value=0.0,
     units=1/u.s/u.s/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB4_Component = 'Binary'
 
 FB5 = p.prefixParameter(parameter_type="float",
     name="FB5",
     value=0.0,
     units=1/u.s/u.s/u.s/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FB5_Component = 'Binary'
 
 # FDX -> Do we need more? Is there a better way to do this?
@@ -209,42 +232,48 @@ FD1 = p.prefixParameter(parameter_type="float",
     name="FD1",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD1_Component = 'FD'
 
 FD2 = p.prefixParameter(parameter_type="float",
     name="FD2",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD2_Component = 'FD'
 
 FD3 = p.prefixParameter(parameter_type="float",
     name="FD3",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD3_Component = 'FD'
 
 FD4 = p.prefixParameter(parameter_type="float",
     name="FD4",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD4_Component = 'FD'
 
 FD5 = p.prefixParameter(parameter_type="float",
     name="FD5",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD5_Component = 'FD'
 
 FD6 = p.prefixParameter(parameter_type="float",
     name="FD6",
     value=0.0,
     units=u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 FD6_Component = 'FD'
 
 # FX, spindown derivatives
@@ -252,19 +281,22 @@ F1 = p.prefixParameter(parameter_type="float",
     name="F1",
     value=0.0,
     units=u.Hz/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 F1_Component = 'Spindown'
 
 F2 = p.prefixParameter(parameter_type="float",
     name="F2",
     value=0.0,
     units=u.Hz/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 F2_Component = 'Spindown'
 
 F3 = p.prefixParameter(parameter_type="float",
     name="F3",
     value=0.0,
     units=u.Hz/u.s/u.s/u.s,
-    frozen = False)
+    frozen = False,
+    convert_tcb2tdb=False)
 F3_Component = 'Spindown'


### PR DESCRIPTION
To allow us to import in the notebooks using the latest versions of PINT, this adds `convert_tcb2tdb=False` to all parameters.

As an aside, I have also replaced all use of "LABMDA" with "LAMBDA"