### PR TITLE
Add a return value to the check_convergence method

### DIFF
--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -1431,28 +1431,30 @@ def check_convergence(fitter):
     """
     chi2_decrease = fitter.resids_init.chi2-fitter.resids.chi2
     message = str(f"chi-squared decreased during fit by {chi2_decrease}")
-    output_val = message
     print(message)
+    output_val = []
+    output_val.append(message)
     if hasattr(fitter, "converged") and fitter.converged:
         message = "Fitter has converged"
         print(message)
-        output_val.append("\n" + message)
+        output_val.append(message)
     else:
         if abs(chi2_decrease)<0.01:
             message = "Fitter has probably converged"
-            output_val.append("\nFitter has probably converged")
+            print(message)
+            output_val.append(message)
         elif chi2_decrease<0:
             message = "Fitter has increased chi2!"
             log.warning(message)
-            output_val.append("\n" + message)
+            output_val.append(message)
         else:
             message = "Fitter may not have converged"
             log.warning(message)
-            output_val.append("\n" + message)
+            output_val.append(message)
     if chi2_decrease > 0.01:
         message = "Input par file is not fully fitted"
         log.warning(message)
-        output_val.append("\n" + message)
+        output_val.append(message)
     return output_val
 
 def file_look(filenm, plot_type = 'profile'):

--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -1424,28 +1424,31 @@ def check_convergence(fitter):
     Parameters
     ==========
     fitter: `pint.fitter` object
+
+    Returns
+    =======
+    output_val: string object that corresponds to the printed outputs of the checker
     """
     chi2_decrease = fitter.resids_init.chi2-fitter.resids.chi2
-    decrease = str(f"chi-squared decreased during fit by {chi2_decrease}")
-    print(decrease)
-    convergence = ""
+    output_val = str(f"chi-squared decreased during fit by {chi2_decrease}")
+    print(f"chi-squared decreased during fit by {chi2_decrease}")
     if hasattr(fitter, "converged") and fitter.converged:
-        convergence = "Fitter has converged"
-        print(convergence)
+        print("Fitter has converged")
+        output_val.append("\nFitter has converged")
     else:
         if abs(chi2_decrease)<0.01:
-            convergence = "Fitter has probably converged"
-            print(convergence)
+            print("Fitter has probably converged")
+            output_val.append("\nFitter has probably converged")
         elif chi2_decrease<0:
             log.warning("Fitter has increased chi2!")
-            convergence = "Fitter has increased chi2!"
+            output_val.append("\nFitter has increased chi2!")
         else:
             log.warning("Fitter may not have converged")
-            convergence = "Fitter may not have converged"
+            output_val.append("\nFitter may not have converged")
     if chi2_decrease > 0.01:
         log.warning("Input par file is not fully fitted")
-        convergence = "Input par file is not fully fitted"
-    return decrease,convergence
+        output_val.append("\nInput par file is not fully fitted")
+    return output_val
 
 def file_look(filenm, plot_type = 'profile'):
     """ Plots profile, GTpd, or YFp for a single file

--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -1430,24 +1430,29 @@ def check_convergence(fitter):
     output_val: string object that corresponds to the printed outputs of the checker
     """
     chi2_decrease = fitter.resids_init.chi2-fitter.resids.chi2
-    output_val = str(f"chi-squared decreased during fit by {chi2_decrease}")
-    print(f"chi-squared decreased during fit by {chi2_decrease}")
+    message = str(f"chi-squared decreased during fit by {chi2_decrease}")
+    output_val = message
+    print(message)
     if hasattr(fitter, "converged") and fitter.converged:
-        print("Fitter has converged")
-        output_val.append("\nFitter has converged")
+        message = "Fitter has converged"
+        print(message)
+        output_val.append("\n" + message)
     else:
         if abs(chi2_decrease)<0.01:
-            print("Fitter has probably converged")
+            message = "Fitter has probably converged"
             output_val.append("\nFitter has probably converged")
         elif chi2_decrease<0:
-            log.warning("Fitter has increased chi2!")
-            output_val.append("\nFitter has increased chi2!")
+            message = "Fitter has increased chi2!"
+            log.warning(message)
+            output_val.append("\n" + message)
         else:
-            log.warning("Fitter may not have converged")
-            output_val.append("\nFitter may not have converged")
+            message = "Fitter may not have converged"
+            log.warning(message)
+            output_val.append("\n" + message)
     if chi2_decrease > 0.01:
-        log.warning("Input par file is not fully fitted")
-        output_val.append("\nInput par file is not fully fitted")
+        message = "Input par file is not fully fitted"
+        log.warning(message)
+        output_val.append("\n" + message)
     return output_val
 
 def file_look(filenm, plot_type = 'profile'):

--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -1426,18 +1426,26 @@ def check_convergence(fitter):
     fitter: `pint.fitter` object
     """
     chi2_decrease = fitter.resids_init.chi2-fitter.resids.chi2
-    print(f"chi-squared decreased during fit by {chi2_decrease}")
+    decrease = str(f"chi-squared decreased during fit by {chi2_decrease}")
+    print(decrease)
+    convergence = ""
     if hasattr(fitter, "converged") and fitter.converged:
-        print("Fitter has converged")
+        convergence = "Fitter has converged"
+        print(convergence)
     else:
         if abs(chi2_decrease)<0.01:
-            print("Fitter has probably converged")
+            convergence = "Fitter has probably converged"
+            print(convergence)
         elif chi2_decrease<0:
             log.warning("Fitter has increased chi2!")
+            convergence = "Fitter has increased chi2!"
         else:
             log.warning("Fitter may not have converged")
+            convergence = "Fitter may not have converged"
     if chi2_decrease > 0.01:
         log.warning("Input par file is not fully fitted")
+        convergence = "Input par file is not fully fitted"
+    return decrease,convergence
 
 def file_look(filenm, plot_type = 'profile'):
     """ Plots profile, GTpd, or YFp for a single file


### PR DESCRIPTION
Add a return value to the check_convergence method of lite_utils to allow for unit testing. There are several such methods in pint_pal that primarily print things instead of returning or modifying variables. If we want unit tests for these, they might need similar modifications.