### PR TITLE
Fixed the error while setting tim drectory for excised tim file.

### DIFF
--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -134,7 +134,7 @@ class TimingConfiguration:
         if excised:
             if self.get_excised():
                 toas = self.get_excised()
-                self.tim_directory = ''
+                self.set_tim_directory = ''
             else: # unset or file does not exist... 
                 log.warning(f"excised-tim is unset or file does not exist")
                 return None, None


### PR DESCRIPTION
As `tim_directory` is now a property of `TimingConfiguration` class with the setter function `set_tim_directory`, it was giving an error while setting the tim directory for excised tim file using `self.tim_directory = ''`. I have now changed it to `self.set_tim_directory = ''` to fix that.