### PR TITLE
Fix setter function names

### DIFF
--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -65,7 +65,7 @@ class TimingConfiguration:
         )
 
     @tim_directory.setter
-    def set_tim_directory(self, tim_directory):
+    def tim_directory(self, tim_directory):
         """
         Set tim directory.
         If a relative path is supplied, it will be turned into an absolute path.
@@ -83,7 +83,7 @@ class TimingConfiguration:
         )
 
     @par_directory.setter
-    def set_par_directory(self, par_directory):
+    def par_directory(self, par_directory):
         """
         Set par directory.
         If a relative path is supplied, it will be turned into an absolute path.


### PR DESCRIPTION
This fixes a bug I introduced in #63 by naming my setter functions incorrectly -- see #82.

I essentially wrote this:
```
class TimingConfiguration:
    @property
    def tim_directory(self):
        # get the tim directory
    @tim_directory.setter
    def set_tim_directory(self):
        # set the tim directory
```
thinking that the name of the `set_tim_directory()` function didn't matter, since the name of the Property was already set by the `tim_directory()` function. But in fact, the name of the setter does matter, and should have been `tim_directory()` for it to work in the usual way, where there is only one property `tim_directory` with both a getter and a setter, which is what I intended.

Here I fix this by renaming `set_tim_directory()` to `tim_directory()`, which is the name it should have had all along.