### PR TITLE
Reduce spurious warnings 

### DIFF
--- a/src/pint_pal/noise_utils.py
+++ b/src/pint_pal/noise_utils.py
@@ -201,8 +201,14 @@ def model_noise(mo, to, vary_red_noise = True, n_iter = int(1e5), using_wideband
     else:
         outdir = base_op_dir + mo.PSR.value + '_wb/'
 
-    if os.path.exists(outdir) and (run_noise_analysis) and (not resume):
-        log.info("INFO: A noise directory for pulsar {} already exists! Re-running noise modeling from scratch".format(mo.PSR.value))
+    if os.path.exists(outdir) and run_noise_analysis and not resume:
+        log.warning(
+            f"A noise directory for pulsar {mo.PSR.value} already exists! "
+            "Please rename the existing directory or specify a new location with "
+            "base_op_dir. If you're trying to resume noise modeling, use "
+            "resume=True with the existing directory. Skipping noise analysis."
+        )
+        return None
     elif os.path.exists(outdir) and (run_noise_analysis) and (resume):
         log.info("INFO: A noise directory for pulsar {} already exists! Re-running noise modeling starting from previous chain".format(mo.PSR.value))
 

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -544,7 +544,9 @@ def pdf_writer(fitter,
 
     # Get some values from the fitter
     start = fitter.toas.first_MJD.value
+    start_ymd = fitter.toas.first_MJD.to_value(format='iso')
     finish = fitter.toas.last_MJD.value
+    finish_ymd = fitter.toas.last_MJD.to_value(format='iso')
     span = finish - start
 
     label = f"{psr} {'narrowband' if NB else 'wideband'}"
@@ -573,8 +575,8 @@ def pdf_writer(fitter,
     for tf in tim_files:
         fsum.write(r'\item ' + verb(tf.split('/')[-1]) + '\n')
     fsum.write(r'\end{itemize}' + "\n")
-    fsum.write('Span: %.1f years (%.1f -- %.1f)\\\\\n ' % (span/365.24,
-        year(float(start)), year(float(finish))))
+    fsum.write('Span: %.1f years (%s -- %s)\\\\\n ' % (span/365.24,
+        str(start_ymd).split(' ')[0], str(finish_ymd).split(' ')[0]))
 
     if NB:
         try:
@@ -1240,10 +1242,14 @@ def check_recentness_noise(tc):
         return None, None
 
     d = os.path.abspath(tc.get_noise_dir())
-    if os.path.isfile(os.path.join(d, "chain*.txt")):
-        noise_runs = glob.glob(os.path.join(d, "chain*.txt"))
-    else:
-        noise_runs = [os.path.dirname(os.path.dirname(os.path.abspath(p))) for p in sorted(glob.glob(os.path.join(d, tc.get_source()+"_"+tc.get_toa_type().lower(), "chain*.txt")))]
+    if glob.glob(os.path.join(d,"chain*.txt")):
+        log.warning(f'Ignoring chains directly in {d}. Chains should be in a subdirectory of {os.path.split(d)[1]} called {tc.get_source()}_{tc.get_toa_type().lower()}')
+    noise_runs = [os.path.dirname(os.path.dirname(os.path.abspath(p))) 
+                  for p in sorted(glob.glob(os.path.join(d,
+                                                    "..",
+                                                    "????-??-??",
+                                                    tc.get_source()+"_"+tc.get_toa_type().lower(),
+                                                    "chain*.txt")))]
     used_chains = os.path.basename(d)
     available_chains = [os.path.basename(n) for n in noise_runs]
     log.info(f"Using: {used_chains}")

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -1247,7 +1247,7 @@ def check_recentness_noise(tc):
     noise_runs = [os.path.dirname(os.path.dirname(os.path.abspath(p))) 
                   for p in sorted(glob.glob(os.path.join(d,
                                                     "..",
-                                                    "????-??-??",
+                                                    "????-??-*",
                                                     tc.get_source()+"_"+tc.get_toa_type().lower(),
                                                     "chain*.txt")))]
     used_chains = os.path.basename(d)

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -716,7 +716,7 @@ def pdf_writer(fitter,
             and pm.frozen
             and pm.value is not None
             and pm.value != 0):
-            if p in {"START", "FINISH", "POSEPOCH", "DMEPOCH", "PEPOCH", "TZRMJD", "DM", "DMX", "NTOA", "CHI2", "DMDATA", "TZRFRQ", "RNAMP", "RNIDX"}:
+            if p in {"START", "FINISH", "POSEPOCH", "DMEPOCH", "PEPOCH", "TZRMJD", "DM", "DMX", "NTOA", "CHI2", "DMDATA", "TZRFRQ", "RNAMP", "RNIDX", "CHI2R", "TRES", "SWP"}:
                 ignoring.append(p)
                 continue
             skip = False

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -1252,6 +1252,15 @@ def check_recentness_noise(tc):
                                                     "chain*.txt")))]
     used_chains = os.path.basename(d)
     available_chains = [os.path.basename(n) for n in noise_runs]
+    
+    if not noise_runs:
+        log.warning('Looking for noise chains in working directory.')
+        noise_runs = [os.path.dirname(os.path.dirname(os.path.abspath(p))) for p in sorted(glob.glob(os.path.join(d, tc.get_source()+"_"+tc.get_toa_type().lower()+"*", "chain*.txt")))]
+        if len(noise_runs) > 1:
+            log.warning(f'{len(noise_runs)} noise chains found in the working directory. Using first in sorted list.')
+        used_chains = os.path.basename(noise_runs[-1])
+        available_chains = [os.path.basename(n) for n in noise_runs]
+
     log.info(f"Using: {used_chains}")
     log.info(f"Available: {' '.join(available_chains)}")
     try:

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -1240,12 +1240,10 @@ def check_recentness_noise(tc):
         return None, None
 
     d = os.path.abspath(tc.get_noise_dir())
-    noise_runs = [os.path.dirname(os.path.dirname(os.path.abspath(p))) 
-                  for p in sorted(glob.glob(os.path.join(d,
-                                                    "..",
-                                                    "*.Noise.*",
-                                                    tc.get_source()+"_"+tc.get_toa_type().lower(),
-                                                    "chain*.txt")))]
+    if os.path.isfile(os.path.join(d, "chain*.txt")):
+        noise_runs = glob.glob(os.path.join(d, "chain*.txt"))
+    else:
+        noise_runs = [os.path.dirname(os.path.dirname(os.path.abspath(p))) for p in sorted(glob.glob(os.path.join(d, tc.get_source()+"_"+tc.get_toa_type().lower(), "chain*.txt")))]
     used_chains = os.path.basename(d)
     available_chains = [os.path.basename(n) for n in noise_runs]
     log.info(f"Using: {used_chains}")


### PR DESCRIPTION
Takes away several params from "Frozen" warning list that are usually frozen. Changes the expected noise directories in both `utils` ~and `noise_utils`~ to remove incorrect warnings. I've made it so that it'll check for chains in both `/nanograv/share/20yr/noise-chains/J1234+5678/YYYY-MM-DD/` and `/nanograv/share/20yr/noise-chains/J1234+5678/YYYY-MM-DD/J1234+5678_<nb/wb>` in case people copy the contents of their noise directory in there instead of the directory itself. (We should discuss this during gitflowers on 2/18/25)