### PR TITLE
Add fastshermanmorrison to requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "notebook",
     "seaborn",
     "gitpython",
+    "fastshermanmorrison-pulsar",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
The [`fastshermanmorrison`](https://github.com/nanograv/fastshermanmorrison) package speeds up linear algebra needed for ECORR in Enterprise, which in turn speeds up noise runs. This PR adds it as a requirement for PINT Pal.