### PR TITLE
Quick fix for finding old noise runs

### DIFF
--- a/src/pint_pal/noise_utils.py
+++ b/src/pint_pal/noise_utils.py
@@ -156,9 +156,13 @@ def analyze_noise(
     try:
         noise_core = co.Core(chaindir=chaindir)
     except:
-        log.error(f"Could not load noise run from {chaindir}. Make sure the path is correct." \
-                  +"Also make sure you have an up-to-date la_forge installation. ")
-        raise ValueError(f"Could not load noise run from {chaindir}. Check path and la_forge installation.")
+        if os.path.isfile(chaindir):
+            log.error(f"Could not load noise run from {chaindir}. Make sure the path is correct. " \
+                      +"Also make sure you have an up-to-date la_forge installation. ")
+            raise ValueError(f"Could not load noise run from {chaindir}. Check path and la_forge installation.")
+        else:
+            log.error(f"No noise runs found in {chaindir}. Make sure the path is correct.") 
+            raise ValueError(f"Could not load noise run from {chaindir}. Check path.")
     if sampler == 'PTMCMCSampler':
         # standard burn ins
         noise_core.set_burn(burn_frac)

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -1238,7 +1238,7 @@ def check_recentness_noise(tc):
         name of the most recent available set of chains
     """
     if not tc.get_noise_dir():
-        log.warning(f"Yaml file does not have a noise-dir field (or it is unset).")
+        log.warning(f"Yaml file does not have a noise-dir field (or it is unset). Will check working directory.")
         return None, None
 
     d = os.path.abspath(tc.get_noise_dir())
@@ -1254,12 +1254,18 @@ def check_recentness_noise(tc):
     available_chains = [os.path.basename(n) for n in noise_runs]
     
     if not noise_runs:
-        log.warning('Looking for noise chains in working directory.')
-        noise_runs = [os.path.dirname(os.path.dirname(os.path.abspath(p))) for p in sorted(glob.glob(os.path.join(d, tc.get_source()+"_"+tc.get_toa_type().lower()+"*", "chain*.txt")))]
-        if len(noise_runs) > 1:
-            log.warning(f'{len(noise_runs)} noise chains found in the working directory. Using first in sorted list.')
-            used_chains = os.path.basename(noise_runs[-1])
-            available_chains = [os.path.basename(n) for n in noise_runs]
+        log.warning('Looking for noise chains in given noise-dir, but does not follow current conventions.')
+        noise_runs = [os.path.dirname(os.path.abspath(p)) for p in sorted(glob.glob(os.path.join(d, tc.get_source()+"_"+tc.get_toa_type().lower()+"*", "chain*.txt")))]
+        if len(noise_runs) > 0:
+            if len(noise_runs) == 1:
+                log.warning(f'{len(noise_runs)} noise chain found in noise-dir.')
+            else:
+                log.warning(f'{len(noise_runs)} noise chains found in noise-dir. Using first in sorted list.')
+            used_chains = os.path.abspath(noise_runs[0])
+            available_chains = [os.path.abspath(n) for n in noise_runs]
+    
+    if not noise_runs:
+        log.warning('No chains found. Will search working directory and apply if found.')
 
     log.info(f"Using: {used_chains}")
     log.info(f"Available: {' '.join(available_chains)}")

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -1258,9 +1258,9 @@ def check_recentness_noise(tc):
         noise_runs = [os.path.dirname(os.path.abspath(p)) for p in sorted(glob.glob(os.path.join(d, tc.get_source()+"_"+tc.get_toa_type().lower()+"*", "chain*.txt")))]
         if len(noise_runs) > 0:
             if len(noise_runs) == 1:
-                log.warning(f'{len(noise_runs)} noise chain found in noise-dir.')
+                log.info(f'{len(noise_runs)} noise chain found in noise-dir.')
             else:
-                log.warning(f'{len(noise_runs)} noise chains found in noise-dir. Using first in sorted list.')
+                log.info(f'{len(noise_runs)} noise chains found in noise-dir. Using first in sorted list.')
             used_chains = os.path.abspath(noise_runs[0])
             available_chains = [os.path.abspath(n) for n in noise_runs]
     

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -1258,8 +1258,8 @@ def check_recentness_noise(tc):
         noise_runs = [os.path.dirname(os.path.dirname(os.path.abspath(p))) for p in sorted(glob.glob(os.path.join(d, tc.get_source()+"_"+tc.get_toa_type().lower()+"*", "chain*.txt")))]
         if len(noise_runs) > 1:
             log.warning(f'{len(noise_runs)} noise chains found in the working directory. Using first in sorted list.')
-        used_chains = os.path.basename(noise_runs[-1])
-        available_chains = [os.path.basename(n) for n in noise_runs]
+            used_chains = os.path.basename(noise_runs[-1])
+            available_chains = [os.path.basename(n) for n in noise_runs]
 
     log.info(f"Using: {used_chains}")
     log.info(f"Available: {' '.join(available_chains)}")


### PR DESCRIPTION
Quick mod to @jeremy-baier 's noise_utils changes. You get a warning about la-forge installation possibly being incorrect even when the file isn't found, which might be confusing. Now it checks for the file. Also there was a bug in my utils change that makes home directory noise runs not work correctly.  Warning: I have not thoroughly tested this change yet, but I know it's preventing people from doing noise runs. Would appreciate a sanity check! 