### PR TITLE
bug fix:  chain comparison not plotting properly

### DIFF
--- a/src/pint_pal/noise_utils.py
+++ b/src/pint_pal/noise_utils.py
@@ -176,9 +176,9 @@ def analyze_noise(
     
     # load in same for comparison noise model
     if chaindir_compare is not None:
-        compare_core = co.Core(chaindir=chaindir)
-        compare_core.set_burn(noise_core.burn)
-        chain_compare = compare_core.chain[int(burn_frac * len(noise_core.chain)) :, :-4]
+        compare_core = co.Core(chaindir=chaindir_compare)
+        compare_core.set_burn(compare_core.burn)
+        chain_compare = compare_core.chain[int(burn_frac * len(compare_core.chain)) :, :-4]
         pars_compare = np.array([p for p in compare_core.params if p not in ['lnlike', 'lnpost', 'chain_accept', 'pt_chain_accept']])
         # if len(pars_compare)+2 != chain_compare.shape[1]:
         #     chain_compare = chain_compare[:, :len(pars_compare)+2]


### PR DESCRIPTION
the new noise chains were being compared to themselves rather than being compared to the old version of the chains which were passed.