### PR TITLE
Correct access to wideband `noise_resids` for PINT 1.1.3

### DIFF
--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -37,6 +37,7 @@ jobs:
             cython
             pint-pulsar
             tempo2
+            libstempo
             enterprise-pulsar
             enterprise_extensions
             scikit-sparse

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -37,7 +37,6 @@ jobs:
             cython
             pint-pulsar
             tempo2
-            libstempo
             enterprise-pulsar
             enterprise_extensions
             scikit-sparse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "nbconvert",
     "ipywidgets>=7.6.3",
     "pypulse>=0.0.1",
-    "numpy<2.0",
+    "numpy",
     "weasyprint",
     "pytest-xdist[psutil]>=2.3.0",
     "notebook",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "nbconvert",
     "ipywidgets>=7.6.3",
     "pypulse>=0.0.1",
-    "numpy",
+    "numpy<2.0",
     "weasyprint",
     "pytest-xdist[psutil]>=2.3.0",
     "notebook",

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -57,10 +57,10 @@ def whiten_resids(fitter, restype = 'postfit'):
         if fitter.is_wideband:
             if restype == 'postfit':
                 time_resids = fitter.resids.residual_objs['toa'].time_resids
-                noise_resids = fitter.resids.noise_resids
+                noise_resids = fitter.resids.toa.noise_resids
             else:
                 time_resids = fitter.resids_init.residual_objs['toa'].time_resids
-                noise_resids = fitter.resids_init.noise_resids
+                noise_resids = fitter.resids_init.toa.noise_resids
         else:
             if restype == 'postfit':
                 time_resids = fitter.resids.time_resids


### PR DESCRIPTION
Fixes #124. In PINT 1.1.3, if `resids` is a `WidebandTOAResiduals` object, there is no longer a `resids.noise_resids` attribute. But the same data can be accessed as `resids.toa.noise_resids`, both in PINT 1.1.3 and in older versions (see also nanograv/PINT#1931). This PR changes the one main place where `resids.noise_resids` is accessed directly on a `WidebandTOAResids` object (in `utils.whiten_resids()`) to use `resids.toa.noise_resids` instead. This should be enough to restore compatibility with PINT 1.1.3.

There is a second occurrence of `resids.noise_resids` in `utils.no_ecorr_average()`, but that function is designed to correctly epoch-average EPTA data, so we can assume no wideband residuals are involved.