### PR TITLE
Convert astropy logging to loguru

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ authors = [
   { name="Anne Archibald", email="anne.archibald@nanograv.org" },
   { name="Kevin Wilson", email="kevin.wilson@nanograv.org" },
   { name="Ross Jennings", email="ross.jennings@nanograv.org" },
-  { name="Jeremy Baier", email="jeremy.baier@nanograv.org"}
+  { name="Jeremy Baier", email="jeremy.baier@nanograv.org"},
+  { name="Michael Lam", email="michael.lam@nanograv.org"}
 ]
 description = "A long-lived repository for NANOGrav Pulsar Timing analysis work."
 readme = "README.md"
@@ -36,6 +37,7 @@ dependencies = [
     "la-forge",
     "arviz",
     "fastshermanmorrison-pulsar",
+    "loguru"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/src/pint_pal/checkin.py
+++ b/src/pint_pal/checkin.py
@@ -1,5 +1,5 @@
 from pint_pal.yamlio import read_yaml, write_yaml
-from astropy import log
+from loguru import logger as log
 import os
 import glob
 import shutil

--- a/src/pint_pal/dmx_utils.py
+++ b/src/pint_pal/dmx_utils.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, Tuple, Union
 import numpy as np
-from astropy import log
+from loguru import logger as log
 import pint
 from pint_pal.utils import apply_cut_flag, apply_cut_select
 

--- a/src/pint_pal/lite_utils.py
+++ b/src/pint_pal/lite_utils.py
@@ -1,7 +1,7 @@
 import sys
 import numpy as np
 import astropy.units as u
-from astropy import log
+from loguru import logger as log
 from astropy.io import fits
 import logging
 import matplotlib.pyplot as plt

--- a/src/pint_pal/make_release.py
+++ b/src/pint_pal/make_release.py
@@ -5,7 +5,7 @@ and gathering results for hand-off to DWG
 
 from pint_pal.yamlio import *
 from pint_pal.timingconfiguration import TimingConfiguration
-from astropy import log
+from loguru import logger as log
 from datetime import datetime
 import subprocess
 import shutil

--- a/src/pint_pal/noise_utils.py
+++ b/src/pint_pal/noise_utils.py
@@ -1,5 +1,5 @@
 import numpy as np, os, json, itertools, time
-from astropy import log
+from loguru import logger as log
 from astropy.time import Time
 
 from enterprise.pulsar import Pulsar

--- a/src/pint_pal/outlier_utils.py
+++ b/src/pint_pal/outlier_utils.py
@@ -2,7 +2,7 @@
 import os, sys
 import matplotlib.pyplot as plt
 import numpy as np
-from astropy import log
+from loguru import logger as log
 from multiprocessing import Pool
 
 # Outlier/Epochalyptica imports

--- a/src/pint_pal/par_checker.py
+++ b/src/pint_pal/par_checker.py
@@ -2,7 +2,7 @@
 
 import re
 import copy
-from astropy import log
+from loguru import logger as log
 import astropy.units as u
 import pint_pal.config
 from pint.modelutils import model_equatorial_to_ecliptic

--- a/src/pint_pal/plot_utils.py
+++ b/src/pint_pal/plot_utils.py
@@ -8,7 +8,7 @@ Code since butchered by many timers.
 import numpy as np
 import matplotlib.pyplot as plt
 import copy
-from astropy import log
+from loguru import logger as log
 import astropy.units as u
 import yaml
 

--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -14,7 +14,7 @@ import pint.models as model
 import pint.fitter
 import numpy as np
 import astropy.units as u
-from astropy import log
+from loguru import logger as log
 from astropy.time import Time
 import yaml
 import glob

--- a/src/pint_pal/timingnotebook.py
+++ b/src/pint_pal/timingnotebook.py
@@ -116,7 +116,7 @@ class TimingNotebook:
         from pint_pal.ftester import run_Ftests
         from pint_pal.timingconfiguration import TimingConfiguration
         import yaml
-        from astropy import log
+        from loguru import logger as log
         import pint.fitter
         from pint.utils import dmxparse
         import os

--- a/src/pint_pal/update_results.py
+++ b/src/pint_pal/update_results.py
@@ -5,7 +5,7 @@ based on output from autoruns on Thorny Flats (or potentially elsewhere).
 
 from pint_pal.yamlio import *
 from pint_pal.timingconfiguration import TimingConfiguration
-from astropy import log
+from loguru import logger as log
 from datetime import datetime
 import subprocess
 import argparse

--- a/src/pint_pal/utils.py
+++ b/src/pint_pal/utils.py
@@ -3,7 +3,7 @@
 import sys
 import numpy as np
 import astropy.units as u
-from astropy import log
+from loguru import logger as log
 from pint.utils import weighted_mean
 import pint.residuals as Resid
 import pint.models.parameter

--- a/src/pint_pal/yamlio.py
+++ b/src/pint_pal/yamlio.py
@@ -6,7 +6,7 @@ if desired; ruyamel.yaml preserves order of existing fields and comments.
 from ruamel.yaml import YAML
 import argparse
 import glob
-from astropy import log
+from loguru import logger as log
 import numpy as np
 from pint_pal import config
 import os


### PR DESCRIPTION
A simple replacement of the astropy logger, solving #121. The `loguru` requirements have been added to `pyproject.toml` as well, along with my author info while I was at it.