### PR TITLE
Rework of JUMP flags in config files and TimingConfiguration

### DIFF
--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -126,12 +126,53 @@ class TimingConfiguration:
             return os.path.join(self.par_directory, self.config['compare-model'])
         return None
 
-    def get_free_params(self, fitter):
-        """Return list of free parameters"""
-        if self.config["free-dmx"]:
-            return self.config['free-params'] + [p for p in fitter.model.params if p.startswith("DMX_")]
-        else:
-            return self.config['free-params']
+    def get_free_params(self, fitter: pint.fitter.Fitter):
+        """ Return list of free parameters """
+        free_params = self.config['free-params']
+        if 'free-dmx' in self.config.keys() and self.config['free-dmx']:
+            free_params += [p for p in fitter.model.params if p.startswith("DMX_")]
+        if 'free-jumps' in self.config.keys():
+            free_params += self.get_free_jumps(fitter=fitter, convert_to_indices=True)
+        return free_params
+
+    def get_free_jumps(self, fitter: pint.fitter.Fitter | None = None, convert_to_indices: bool = False):
+        """
+        Return list of free JUMPs
+
+        Parameters
+        ----------
+        fitter: pint.fitter.Fitter, default=None
+            Fitter object used if convert_to_indices==True. See below. 
+        convert_to_indices : bool, default=False
+            Returns JUMPs in the format JUMP1, JUMP2, etc., rather than JUMP -flag flag_value.
+            fitter cannot be None as it needs to reference this object. If it is None, the parameter is taken to be False regardless of how it was set.
+
+        """
+        if fitter is None:
+            convert_to_indices = False
+
+        retval = None
+        if 'free-jumps' in self.config.keys():
+            free_jumps = self.config['free-jumps']
+            retval = [] # new list, do not write over the data
+        
+            for free_jump in free_jumps:
+                flag, value = free_jump
+                if convert_to_indices:
+                    pint_jumps = fitter.model.jumps
+                    found = False
+                    for jump in pint_jumps:
+                        if fitter.model[jump].key == flag and fitter.model[jump].key_value[0] == value: #assumes only one key_value
+                            found = True
+                            retval.append(jump)
+                            break
+                    if not found:
+                        raise KeyError("JUMP {flag} {value} not found in timing model.")
+                else:
+                    retval.append(f"JUMP {flag} {value}")
+
+        return retval
+
         
     #def get_febe_pairs(self):
     #    febe_list = []

--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -129,11 +129,12 @@ class TimingConfiguration:
     def get_free_params(self, fitter: pint.fitter.Fitter):
         """ Return list of free parameters """
         free_params = self.config['free-params']
+        retval = free_params[:] # copy list, do not write over the data
         if 'free-dmx' in self.config.keys() and self.config['free-dmx']:
-            free_params += [p for p in fitter.model.params if p.startswith("DMX_")]
+            retval += [p for p in fitter.model.params if p.startswith("DMX_")]
         if 'free-jumps' in self.config.keys():
-            free_params += self.get_free_jumps(fitter=fitter, convert_to_indices=True)
-        return free_params
+            retval += self.get_free_jumps(fitter=fitter, convert_to_indices=True)
+        return retval
 
     def get_free_jumps(self, fitter: pint.fitter.Fitter | None = None, convert_to_indices: bool = False):
         """
@@ -154,9 +155,9 @@ class TimingConfiguration:
         retval = None
         if 'free-jumps' in self.config.keys():
             free_jumps = self.config['free-jumps']
-            retval = [] # new list, do not write over the data
+            retval = free_jumps[:] # copy list, do not write over the data
         
-            for free_jump in free_jumps:
+            for i, free_jump in enumerate(free_jumps):
                 flag, value = free_jump
                 if convert_to_indices:
                     pint_jumps = fitter.model.jumps
@@ -164,12 +165,12 @@ class TimingConfiguration:
                     for jump in pint_jumps:
                         if fitter.model[jump].key == flag and fitter.model[jump].key_value[0] == value: #assumes only one key_value
                             found = True
-                            retval.append(jump)
+                            retval[i] = jump
                             break
                     if not found:
                         raise KeyError("JUMP {flag} {value} not found in timing model.")
                 else:
-                    retval.append(f"JUMP {flag} {value}")
+                    retval[i] = f"JUMP {flag} {value}"
 
         return retval
 

--- a/src/pint_pal/timingconfiguration.py
+++ b/src/pint_pal/timingconfiguration.py
@@ -146,11 +146,11 @@ class TimingConfiguration:
             Fitter object used if convert_to_indices==True. See below. 
         convert_to_indices : bool, default=False
             Returns JUMPs in the format JUMP1, JUMP2, etc., rather than JUMP -flag flag_value.
-            fitter cannot be None as it needs to reference this object. If it is None, the parameter is taken to be False regardless of how it was set.
+            fitter cannot be None as it needs to reference this object. If it is None and convert_to_indices is True, raise an exception
 
         """
-        if fitter is None:
-            convert_to_indices = False
+        if fitter is None and convert_to_indices:
+            raise ValueError("Fitter object cannot be None, is required with convert_to_indices==True")
 
         retval = None
         if 'free-jumps' in self.config.keys():

--- a/tests/configs/tctest.nb.yaml
+++ b/tests/configs/tctest.nb.yaml
@@ -9,7 +9,9 @@ toas:
 - J0605+3757.Rcvr1_2.GUPPI.15y.x.nb.tim
 - J0605+3757.Rcvr_800.GUPPI.15y.x.nb.tim
 
-free-params: [ELONG, ELAT, PMELONG, PMELAT, PX, F0, F1, A1, PB, T0, E, OM, JUMP1]
+free-params: [ELONG, ELAT, PMELONG, PMELAT, PX, F0, F1, A1, PB, T0, E, OM]
+free-jumps:
+- ["-fe", "Rcvr_800"]
 free-dmx: Yes
 toa-type: NB
 fitter: DownhillGLSFitter

--- a/tests/test_timingconfiguration.py
+++ b/tests/test_timingconfiguration.py
@@ -5,6 +5,7 @@ These tests are performed on YAML configuration files
 '''
 import pytest
 from pathlib import Path
+from pint.fitter import DownhillGLSFitter
 from pint_pal.timingconfiguration import TimingConfiguration
 
 
@@ -31,6 +32,14 @@ def PSR():
 def test_get_source(tc, PSR):
     print(PSR)
     assert tc.get_source() == PSR
+
+def test_get_free_params(tc):
+    mo, to = tc.get_model_and_toas()
+    fo = DownhillGLSFitter(to, mo)
+    assert "ELONG" in tc.get_free_params(fo)
+    assert "JUMP1" in tc.get_free_params(fo)
+    assert tc.get_free_jumps()[0] == "JUMP -fe Rcvr_800"
+    assert tc.get_free_jumps(fitter=fo, convert_to_indices=True)[0] == "JUMP1"
 
 def test_get_model_and_toas(tc, PSR):
     mo, to = tc.get_model_and_toas()


### PR DESCRIPTION
As discussed on calls and in preparation for the `JumpChecker` (part of #147), JUMPs can now be listed separately in the config files with a `free-jumps:` key and a list, for example in the notation we've proposed:

```
free-jumps:
- ["-fe", "Rcvr_800"]
```

`TimingConfiguration` now has a `get_free_jumps()` function which will return the list of free jumps either as `["JUMP -fe Rcvr_800"]` or `JUMP1` depending on if `convert_to_indices` is set to `True`  (for the latter) *and* a fitter object is provided. If the fitter object is not provided, then `convert_to_indices` overrides to `False` but we should discuss this choice. The `get_free_params()` function now uses `get_free_jumps()` under the hood. The way this operates now, the old method of listing `JUMP1`, `JUMP2`, etc, in `free-params` is still respected. However, if one chooses to use both methods, they would have to worry about collisions and this is not checked.

This PR also fixes some minor issues in `free-params`. If the function was called multiple times, then the list would be modified in place repeatedly, leading to duplicate parameters being returned; I am not sure how this interacts with PINT so maybe it would be okay but it is still odd to have multiple copies of the parameters returned. It also makes sure that `free-dmx` is in the config file and does not assume it is there just in case.

A corresponding unit test that coverts both `get_free_param()` and `get_free_jumps()` has been implemented, and the test config file has been modified with the new JUMP syntax.
